### PR TITLE
Fix Chest Lock exploit

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/ChestLockListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ChestLockListener.java
@@ -118,13 +118,13 @@ public class ChestLockListener implements Listener {
     }
 
     private Block getOtherHalfOfChest(Block block) {
-        if (!(block.getState() instanceof DoubleChest)) {
+        if (block.getType() != Material.CHEST && block.getType() != Material.TRAPPED_CHEST) {
             return null;
         }
 
         return Arrays.stream(CARDINAL_FACES)
                 .map(block::getRelative)
-                .filter(otherBlock -> otherBlock.getType() == Material.CHEST)
+                .filter(adjacentBlock -> adjacentBlock.getType() == block.getType())
                 .findFirst()
                 .orElse(null);
     }
@@ -133,7 +133,8 @@ public class ChestLockListener implements Listener {
         return Arrays.stream(CARDINAL_FACES)
                 .map(block::getRelative)
                 .filter(otherBlock -> otherBlock.getBlockData() instanceof WallSign)
-                .map(otherBlock -> (Sign) otherBlock)
+                .filter(otherBlock -> otherBlock.getState() instanceof Sign)
+                .map(otherBlock -> (Sign) otherBlock.getState())
                 .findFirst()
                 .orElse(null);
     }


### PR DESCRIPTION
# I have not yet tested this, either test it yourself, or I will get to it tomorrow. Once tested, it can be moved out of the draft stage.
---
This fixes an exploit with the chest locking mechanism that allowed double chests to be opened by non-trusted and non-owners in certain cases. Repro steps were provided in Discord to @NRProjects.