### PR TITLE
Figure out nearby players to Wither easier

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/WitherSpawnListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/WitherSpawnListener.java
@@ -1,7 +1,5 @@
 package plugins.nate.smp.listeners;
 
-import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -12,29 +10,14 @@ import plugins.nate.smp.utils.ChatUtils;
 public class WitherSpawnListener implements Listener {
     @EventHandler
     public void onWitherSpawn(CreatureSpawnEvent event) {
-        if (event.getEntityType() == EntityType.WITHER) {
-            event.setCancelled(true);
-
-            Location spawnLocation = event.getLocation();
-            World world = spawnLocation.getWorld();
-            Player closestPlayer = null;
-            double closestDistance = Double.MAX_VALUE;
-
-            for (Player player : world.getPlayers()) {
-                double distance = player.getLocation().distance(spawnLocation);
-                if (distance < closestDistance) {
-                    closestDistance = distance;
-                    closestPlayer = player;
-                }
-            }
-
-            if (closestPlayer != null & closestDistance < 8) {
-                closestPlayer.sendMessage(ChatUtils.coloredChat("&c&lWithers are disabled on this server."));
-            }
+        if (event.getEntityType() != EntityType.WITHER) {
+            return;
         }
 
+        event.setCancelled(true);
 
-
-
+        event.getEntity().getNearbyEntities(8, 8, 8).stream()
+                .filter(ent -> ent instanceof Player)
+                .forEach(p -> p.sendMessage(ChatUtils.coloredChat("&c&lWithers are disabled on this server.")));
     }
 }


### PR DESCRIPTION
# I have not tested this, but it seems very straightforward. Test before merging, or I will tomorrow.
---
This PR optimizes finding the player nearest to the Wither by using the Spigot provided method "getNearbyEntities."