### PR TITLE
Fix for anvil issues when working with Custom Enchants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'plugins.nate'
-version = '1.5.1'
+version = ''
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'plugins.nate'
-version = ''
+version = '1.5.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/plugins/nate/smp/managers/EnchantmentManager.java
+++ b/src/main/java/plugins/nate/smp/managers/EnchantmentManager.java
@@ -11,19 +11,26 @@ import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
 import plugins.nate.smp.enchantments.CustomEnchant;
 import plugins.nate.smp.enchantments.TimberEnchant;
 import plugins.nate.smp.enchantments.VeinMinerEnchant;
+import plugins.nate.smp.utils.SMPUtils;
 
 import java.lang.reflect.Field;
 import java.util.*;
 
 public class EnchantmentManager implements Listener {
     public static final Map<String, Enchantment> ENCHANTMENTS = new HashMap<>();
+    public static final Map<Enchantment, String> LORE_MAP = new HashMap<>();
+
 
     static {
         ENCHANTMENTS.put("vein_miner", new VeinMinerEnchant());
         ENCHANTMENTS.put("timber", new TimberEnchant());
+
+        LORE_MAP.put(new VeinMinerEnchant(), ChatColor.GOLD + "Vein Miner");
+        LORE_MAP.put(new TimberEnchant(), ChatColor.GOLD + "Timber");
     }
 
     public static void registerEnchantment(String key) {
@@ -91,35 +98,86 @@ public class EnchantmentManager implements Listener {
             return;
         }
 
+        if (firstItem.getType() == Material.ENCHANTED_BOOK) {
+            return;
+        }
+
+        if (hasCustomEnchant(firstItem) && hasCustomEnchant(secondItem) && firstItem.getType() != secondItem.getType()) {
+            return;
+        }
+
+        Map<Enchantment, Integer> mergedEnchantments = mergeEnchantments(firstItem.getEnchantments(), secondItem.getEnchantments());
+
+        ItemStack resultItem = event.getResult();
+        if (resultItem == null || hasCustomEnchant(secondItem)) {
+            resultItem = firstItem.clone();
+        }
+
+        ItemMeta resultMeta = resultItem.getItemMeta();
+
         if (secondItem.getType() == Material.ENCHANTED_BOOK) {
             EnchantmentStorageMeta bookMeta = (EnchantmentStorageMeta) secondItem.getItemMeta();
-
-            ENCHANTMENTS.values().stream()
-                    .filter(enchantment -> enchantment instanceof CustomEnchant)
-                    .filter(enchantment -> enchantment.canEnchantItem(firstItem))
-                    .filter(bookMeta::hasStoredEnchant)
-                    .findFirst()
-                    .ifPresent(enchantment -> {
-                        ItemMeta toolMeta = firstItem.getItemMeta();
-
-                        String enchantLore = ((CustomEnchant) enchantment).getLore();
-
-                        if (toolMeta.hasLore() && toolMeta.getLore().contains(enchantLore)) {
-                            return;
-                        }
-
-                        ItemStack resultItem = firstItem.clone();
-                        ItemMeta resultMeta = resultItem.getItemMeta();
-
-                        List<String> lore = resultMeta.hasLore() ? resultMeta.getLore() : new ArrayList<>();
-                        lore.add(enchantLore);
-                        resultMeta.setLore(lore);
-
-                        resultItem.setItemMeta(resultMeta);
-                        resultItem.addUnsafeEnchantment(enchantment, 1);
-
-                        event.setResult(resultItem);
-                    });
+            if (bookMeta != null && bookMeta.hasStoredEnchants()) {
+                mergedEnchantments = mergeEnchantments(mergedEnchantments, bookMeta.getStoredEnchants());
+            }
         }
+
+        mergedEnchantments.forEach((enchantment, level) -> resultMeta.addEnchant(enchantment, level, true));
+
+        List<String> resultLore = getCustomLore(mergedEnchantments);
+        resultMeta.setLore(resultLore);
+        resultItem.setItemMeta(resultMeta);
+        
+        event.setResult(resultItem);
+    }
+
+    private static boolean hasCustomEnchant(@NotNull ItemStack item) {
+        if (item.getItemMeta() == null) {
+            return false;
+        }
+
+        for (Map.Entry<Enchantment, Integer> entry : item.getEnchantments().entrySet()) {
+            Enchantment enchantment = entry.getKey();
+            String enchantmentKey = enchantment.getKey().getKey();
+
+            if (ENCHANTMENTS.containsKey(enchantmentKey)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Map<Enchantment, Integer> mergeEnchantments(Map<Enchantment, Integer> firstItemEnchants, Map<Enchantment, Integer> secondItemEnchants) {
+        Map<Enchantment, Integer> mergedEnchantments = new HashMap<>(firstItemEnchants);
+
+        secondItemEnchants.forEach((enchantment, level) -> {
+            if (mergedEnchantments.containsKey(enchantment)) {
+                int existingLevel = mergedEnchantments.get(enchantment);
+                if (existingLevel == level) {
+                    mergedEnchantments.put(enchantment, Math.min(existingLevel + 1, enchantment.getMaxLevel()));
+                } else {
+                    mergedEnchantments.put(enchantment, Math.max(existingLevel, level));
+                }
+            } else {
+                mergedEnchantments.put(enchantment, level);
+            }
+        });
+
+        return mergedEnchantments;
+    }
+
+    private static List<String> getCustomLore(Map<Enchantment, Integer> enchantments) {
+        List<String> customLore = new ArrayList<>();
+
+        for (Enchantment enchantment : enchantments.keySet()) {
+            if (LORE_MAP.containsKey(enchantment)) {
+                customLore.add(LORE_MAP.get(enchantment));
+            }
+        }
+
+        return customLore;
     }
 }
+
+

--- a/src/main/java/plugins/nate/smp/managers/EnchantmentManager.java
+++ b/src/main/java/plugins/nate/smp/managers/EnchantmentManager.java
@@ -15,24 +15,31 @@ import org.jetbrains.annotations.NotNull;
 import plugins.nate.smp.enchantments.CustomEnchant;
 import plugins.nate.smp.enchantments.TimberEnchant;
 import plugins.nate.smp.enchantments.VeinMinerEnchant;
-import plugins.nate.smp.utils.SMPUtils;
 
 import java.lang.reflect.Field;
 import java.util.*;
 
 public class EnchantmentManager implements Listener {
+    // Maps for storing custom enchantments and their corresponding lore.
     public static final Map<String, Enchantment> ENCHANTMENTS = new HashMap<>();
     public static final Map<Enchantment, String> LORE_MAP = new HashMap<>();
 
-
+    // Static initializer to populate the enchantments and lore map
     static {
+        // Initialize custom enchantments
         ENCHANTMENTS.put("vein_miner", new VeinMinerEnchant());
         ENCHANTMENTS.put("timber", new TimberEnchant());
 
+        // Initialize lore for custom enchantments
         LORE_MAP.put(new VeinMinerEnchant(), ChatColor.GOLD + "Vein Miner");
         LORE_MAP.put(new TimberEnchant(), ChatColor.GOLD + "Timber");
     }
 
+    /**
+     * Registers the custom enchantments
+     *
+     * @param key The key of the custom enchantment to register.
+     */
     public static void registerEnchantment(String key) {
         try {
             Field f = Enchantment.class.getDeclaredField("acceptingNew");
@@ -44,14 +51,29 @@ public class EnchantmentManager implements Listener {
         }
     }
 
+    /**
+     * Retrieves a custom enchantment by its key.
+     *
+     * @param key The key of the enchantment.
+     * @return The enchantment associated with the given key.
+     */
     public static Enchantment getEnchantment(String key) {
         return ENCHANTMENTS.get(key);
     }
 
+    /**
+     * Registers all custom enchantments.
+     */
     public static void registerEnchants() {
         ENCHANTMENTS.keySet().forEach(EnchantmentManager::registerEnchantment);
     }
 
+    /**
+     * Event handler for the enchant item event.
+     * Applies custom enchantments based on certain conditions.
+     *
+     * @param event The enchant item event.
+     */
     @EventHandler
     public static void onEnchantItem(EnchantItemEvent event) {
         ItemStack item = event.getItem();
@@ -89,32 +111,47 @@ public class EnchantmentManager implements Listener {
                 });
     }
 
+    /**
+     * Handles the anvil events when working with custom enchantments. This method is called whenever items are placed in both slots of an anvil.
+     * It manages the merging of enchantments from two items, ensuring custom enchantments are applied correctly and generating
+     * the appropriate lore for the result item. This method also handles special cases, such as when an enchanted book is involved.
+     *
+     * @param event The PrepareAnvilEvent provided by the Minecraft server API.
+     */
     @EventHandler
     public static void onAnvilPrepare(PrepareAnvilEvent event) {
+        // Retrieve the items in the first and second slots of the anvil.
         ItemStack firstItem = event.getInventory().getItem(0);
         ItemStack secondItem = event.getInventory().getItem(1);
 
+        // Return early if either slot is empty.
         if (firstItem == null || secondItem == null) {
             return;
         }
 
+        // Returns early if the first item is an enchanted book.
         if (firstItem.getType() == Material.ENCHANTED_BOOK) {
             return;
         }
 
+        // Prevent merging if both items have custom enchantments but are of different types.
         if (hasCustomEnchant(firstItem) && hasCustomEnchant(secondItem) && firstItem.getType() != secondItem.getType()) {
             return;
         }
 
+        // Merge the enchantments from both items.
         Map<Enchantment, Integer> mergedEnchantments = mergeEnchantments(firstItem.getEnchantments(), secondItem.getEnchantments());
 
+        // Determine the result item. Clone the first item if the second item has a custom enchantment or if the default result is null.
         ItemStack resultItem = event.getResult();
         if (resultItem == null || hasCustomEnchant(secondItem)) {
             resultItem = firstItem.clone();
         }
 
+        // Retrieve and prepare the metadata for the result item.
         ItemMeta resultMeta = resultItem.getItemMeta();
 
+        // If the second item is an enchanted book with stored enchantments, merge these enchantments too.
         if (secondItem.getType() == Material.ENCHANTED_BOOK) {
             EnchantmentStorageMeta bookMeta = (EnchantmentStorageMeta) secondItem.getItemMeta();
             if (bookMeta != null && bookMeta.hasStoredEnchants()) {
@@ -122,15 +159,24 @@ public class EnchantmentManager implements Listener {
             }
         }
 
+        // Apply all merged enchantments to the result item's metadata.
         mergedEnchantments.forEach((enchantment, level) -> resultMeta.addEnchant(enchantment, level, true));
 
+        // Generate and set custom lore for the result item based on the merged enchantments.
         List<String> resultLore = getCustomLore(mergedEnchantments);
         resultMeta.setLore(resultLore);
+
+        // Finalize the result item by setting its metadata and setting it as the event's result.
         resultItem.setItemMeta(resultMeta);
-        
         event.setResult(resultItem);
     }
 
+    /**
+     * Checks if an item has a custom enchantment.
+     *
+     * @param item The item to check for custom enchantments.
+     * @return true if the item has a custom enchantment, false otherwise.
+     */
     private static boolean hasCustomEnchant(@NotNull ItemStack item) {
         if (item.getItemMeta() == null) {
             return false;
@@ -148,6 +194,13 @@ public class EnchantmentManager implements Listener {
         return false;
     }
 
+    /**
+     * Merges the enchantments from two maps, choosing the highest level of overlapping enchantments.
+     *
+     * @param firstItemEnchants  Enchantments from the first item.
+     * @param secondItemEnchants Enchantments from the second item.
+     * @return A map containing the merged enchantments.
+     */
     private static Map<Enchantment, Integer> mergeEnchantments(Map<Enchantment, Integer> firstItemEnchants, Map<Enchantment, Integer> secondItemEnchants) {
         Map<Enchantment, Integer> mergedEnchantments = new HashMap<>(firstItemEnchants);
 
@@ -167,6 +220,12 @@ public class EnchantmentManager implements Listener {
         return mergedEnchantments;
     }
 
+    /**
+     * Generates a list of custom lore based on the enchantments present.
+     *
+     * @param enchantments The enchantments to generate lore for.
+     * @return A list of lore strings.
+     */
     private static List<String> getCustomLore(Map<Enchantment, Integer> enchantments) {
         List<String> customLore = new ArrayList<>();
 


### PR DESCRIPTION
Closes #22

### Description:
This pull request addresses the issue where any interaction with an anvil involving an item with a custom enchantment leads to the loss of the enchantment while retaining the lore. The fix ensures that custom enchantments are preserved during various anvil operations such as renaming, adding other enchantments, and combining tools.