### PR TITLE
Add support in build.gradle for auto exporting to a local test server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .gradle/
 .idea/
+local.properties

--- a/build.gradle
+++ b/build.gradle
@@ -45,3 +45,34 @@ processResources {
         expand props
     }
 }
+
+def localProperties = new File('local.properties')
+def externalOutputDir
+
+if (localProperties.exists()) {
+    def properties = new Properties()
+    localProperties.withInputStream { InputStream stream ->
+        properties.load(stream)
+    }
+
+    // To use this, create a local.properties file in the root directory of this project.
+    // Populate it with:
+    // TEST_SERVER_PLUGINS_DIRECTORY=
+    // Do not surround the string in quotes. Your build will now automatically be put into the test server.
+    externalOutputDir = properties.getProperty('TEST_SERVER_PLUGINS_DIRECTORY')
+}
+
+tasks.register('createExternalOutputDir') {
+    doLast {
+        if (externalOutputDir) {
+            file(externalOutputDir).mkdirs()
+        }
+    }
+}
+
+// Configure the jar task
+jar {
+    destinationDirectory = file(externalOutputDir)
+
+    dependsOn createExternalOutputDir
+}


### PR DESCRIPTION
This PR adds support for having a `local.properties` file where you can specify the `plugins` directory of your local test server. If you set this, when you run `jar`, the jar will automatically be copied into your plugins folder for easier reloading.

For example, my local properties has this line:
`TEST_SERVER_PLUGINS_DIRECTORY=D\:\\Documents\\SMP\\plugins`