### PR TITLE
Fix elytra gliding

### DIFF
--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -11,6 +11,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import plugins.nate.smp.managers.ElytraGlidingTracker;
 import plugins.nate.smp.managers.EnchantmentManager;
 import plugins.nate.smp.managers.RecipeManager;
 import plugins.nate.smp.managers.TrustManager;
@@ -33,12 +34,12 @@ public final class SMP extends JavaPlugin {
     public final File prefixesFile = new File(getDataFolder() + "/prefixes.yml");
     public FileConfiguration prefixes;
 
+
     @Override
     public void onEnable() {
         super.onEnable();
         plugin = this;
         coreProtect = SMPUtils.loadCoreProtect();
-
 
         TrustManager.init(this.getDataFolder());
 
@@ -47,6 +48,7 @@ public final class SMP extends JavaPlugin {
         CommandRegistration.registerCommands(this);
         EnchantmentManager.registerEnchants();
         RecipeManager.registerRecipes();
+        ElytraGlidingTracker.startTracking();
 
         getPrefixes().options().copyDefaults(true);
         saveDefaultPrefixes();
@@ -76,7 +78,6 @@ public final class SMP extends JavaPlugin {
     public static CoreProtectAPI getCoreProtect() {
         return coreProtect;
     }
-
 
     public FileConfiguration getPrefixes() {
         if (prefixes == null) {
@@ -112,3 +113,4 @@ public final class SMP extends JavaPlugin {
         }
     }
 }
+

--- a/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
@@ -1,0 +1,45 @@
+package plugins.nate.smp.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import plugins.nate.smp.managers.ElytraGlidingTracker;
+
+public class ElytraFallListener implements Listener {
+    @EventHandler
+    public void onGlide(PlayerMoveEvent e) {
+        Player p = e.getPlayer();
+        if (p.isGliding()) {
+            ElytraGlidingTracker.gliding.add(p);
+        } else {
+            ElytraGlidingTracker.gliding.remove(p);
+        }
+    }
+
+    //High priority may not be a requirement here, but I think it's fair to assume we should be pretty high up on
+    //the list since we're rewriting a core mechanic.
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDamage(EntityDamageEvent e) {
+        if (!(e.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        if (e.getCause() != EntityDamageEvent.DamageCause.FALL) {
+            return;
+        }
+
+        if (ElytraGlidingTracker.calculatedDamageMap.containsKey(player)) {
+            double calculatedDamage = ElytraGlidingTracker.calculatedDamageMap.get(player);
+            if (calculatedDamage <= 0) {
+                e.setCancelled(true);
+            }
+
+            e.setDamage(calculatedDamage);
+            ElytraGlidingTracker.calculatedDamageMap.remove(player);
+            ElytraGlidingTracker.lastLocationMap.remove(player);
+        }
+    }
+}

--- a/src/main/java/plugins/nate/smp/managers/ElytraGlidingTracker.java
+++ b/src/main/java/plugins/nate/smp/managers/ElytraGlidingTracker.java
@@ -1,0 +1,79 @@
+package plugins.nate.smp.managers;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import plugins.nate.smp.records.PlayerPoint;
+import plugins.nate.smp.SMP;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Purpose of this class:
+ * Minecraft has a bug in the game where if you if are gliding at an angle steeper than ~36.9 degrees, you will
+ * take damage based on the height you jumped from. If you had a superflat world and teleported 120 blocks above
+ * your spawn, then glided down at a 36.8 degree angle, you would live and take no damage. If you repeated this,
+ * instead going at a 36.9 degree angle, you would die.
+ * <p>
+ * This tracker takes the player's last position and
+ * their current position, and calculates a speed. Then, using fall speed where damage starts and where it becomes
+ * lethal, extrapolates that into a damage scale that's comparable for Elytras.
+ * <p>
+ * This results in a 43.8 degree angle being the first damaging angle for Elytras, and a 62.7 degree angle being the
+ * new point of lethality. This is affected by feather falling as well, and the new lethal angle becomes ~75 degrees.
+ * <p>
+ * <a href="https://bugs.mojang.com/browse/MC-210371">See more about this bug</a>
+ */
+public class ElytraGlidingTracker {
+    public static Set<Player> gliding = new HashSet<>();
+    public static HashMap<Player, Double> calculatedDamageMap = new HashMap<>();
+    public static Map<Player, PlayerPoint> lastLocationMap = new HashMap<>();
+
+    public static void startTracking() {
+        new BukkitRunnable() {
+            @Override
+            public void run() {
+                for (Player player : gliding) {
+                    if (!lastLocationMap.containsKey(player)) {
+                        //If we don't have a last location, we can't calculate the speed over time.
+                        //So, just insert their current location and move on.
+                        lastLocationMap.put(player, new PlayerPoint(player.getLocation(), System.currentTimeMillis()));
+                        continue;
+                    }
+
+                    PlayerPoint playerPoint = lastLocationMap.get(player);
+
+                    //Gets how long since we last calculated damage between two locations.
+                    long elapsedTime = System.currentTimeMillis() - playerPoint.time();
+                    if (elapsedTime == 0) {
+                        return;
+                    }
+
+                    Location lastLocation = playerPoint.location();
+                    double distance = lastLocation.distance(player.getLocation());
+                    if (distance == 0) {
+                        return;
+                    }
+
+                    //Change in Y between player's current location and their "last" location
+                    //(About a tick, but really varies between 49-51ms)
+                    double deltaY = Math.abs(lastLocation.getY() - player.getLocation().getY());
+                    double verticalSpeed = deltaY / elapsedTime;
+
+                    //Derived from fall damage values.
+                    //A 4 block fall (the first one that damages you) has a vertical speed of ~0.013
+                    //A 24 block fall (first lethal fall height) has a vertical speed of ~0.032
+                    //Extrapolating between these two points, you can create the slope formula
+                    //y = 1052.63x - 12.68 where x is vertical speed.
+                    double calculatedDamage = 1052.63 * verticalSpeed - 12.68;
+
+                    calculatedDamageMap.put(player, calculatedDamage);
+                    lastLocationMap.put(player, new PlayerPoint(player.getLocation(), System.currentTimeMillis()));
+                }
+            }
+        }.runTaskTimer(SMP.getPlugin(), 0L, 1L);
+    }
+}

--- a/src/main/java/plugins/nate/smp/records/PlayerPoint.java
+++ b/src/main/java/plugins/nate/smp/records/PlayerPoint.java
@@ -1,0 +1,10 @@
+package plugins.nate.smp.records;
+
+import org.bukkit.Location;
+
+/**
+ * Used for Elytra tracking to store where a player was at a given time
+ * @param location Player's location at the captured time
+ * @param time Epoch timestamp at time of capture
+ */
+public record PlayerPoint(Location location, long time) {}

--- a/src/main/java/plugins/nate/smp/utils/EventRegistration.java
+++ b/src/main/java/plugins/nate/smp/utils/EventRegistration.java
@@ -24,5 +24,6 @@ public class EventRegistration {
         pm.registerEvents(new TimberListener(), plugin);
         pm.registerEvents(new AntiEntityGriefListener(), plugin);
         pm.registerEvents(new PlayerJoinListener(), plugin);
+        pm.registerEvents(new ElytraFallListener(), plugin);
     }
 }


### PR DESCRIPTION
This is a bug present in the base game that we're fixing, documented at https://bugs.mojang.com/browse/MC-210371.

Minecraft has a bug in the game where if you if are gliding at an angle steeper than ~36.9 degrees, you will take damage based on the height you jumped from. If you had a superflat world and teleported 120 blocks above your spawn, then glided down at a 36.8 degree angle, you would live and take no damage. If you repeated this, instead going at a 36.9 degree angle, you would die.

You can recreate it using the above steps.

This PR results in a 43.8 degree angle being the first damaging angle for Elytras, and a 62.7 degree angle being the new point of lethality. This is affected by feather falling as well, and the new lethal angle becomes ~75 degrees.