### PR TITLE
Fix elytra last location trying to calculate interdimensionally

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
@@ -16,6 +16,7 @@ public class ElytraFallListener implements Listener {
             ElytraGlidingTracker.gliding.add(p);
         } else {
             ElytraGlidingTracker.gliding.remove(p);
+            ElytraGlidingTracker.lastLocationMap.remove(p);
         }
     }
 

--- a/src/main/java/plugins/nate/smp/managers/ElytraGlidingTracker.java
+++ b/src/main/java/plugins/nate/smp/managers/ElytraGlidingTracker.java
@@ -46,16 +46,21 @@ public class ElytraGlidingTracker {
 
                     PlayerPoint playerPoint = lastLocationMap.get(player);
 
+                    Location lastLocation = playerPoint.location();
+                    if (player.getLocation().getWorld() != lastLocation.getWorld()) {
+                        lastLocationMap.remove(player);
+                        continue;
+                    }
+
+                    double distance = lastLocation.distance(player.getLocation());
+                    if (distance == 0) {
+                        continue;
+                    }
+
                     //Gets how long since we last calculated damage between two locations.
                     long elapsedTime = System.currentTimeMillis() - playerPoint.time();
                     if (elapsedTime == 0) {
-                        return;
-                    }
-
-                    Location lastLocation = playerPoint.location();
-                    double distance = lastLocation.distance(player.getLocation());
-                    if (distance == 0) {
-                        return;
+                        continue;
                     }
 
                     //Change in Y between player's current location and their "last" location


### PR DESCRIPTION
We were getting some noise in the console about distance being unable to be calculated interdimensionally. This should fix that by removing people from the last location map when they stop gliding, but if for some reason that fails, they're also removed if we try to calculate distance interdimensionally. (If we ever TP'd someone who was gliding or something.)

Also, instead of using `return`, we use `continue` now. This was likely causing bugs.