### PR TITLE
Added forcelock command

### DIFF
--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import static plugins.nate.smp.utils.ChatUtils.sendMessage;
 
 public class SMPCommand implements CommandExecutor, TabCompleter {
-    private static final Set<String> VALID_SUBCOMMANDS = Set.of("help", "features", "reload", "forcelock", "trust", "untrust", "trustlist", "lock", "unlock");
+    private static final Set<String> VALID_SUBCOMMANDS = Set.of("help", "features", "reload", "forcelock", "lockholder", "trust", "untrust", "trustlist", "lock", "unlock");
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
@@ -50,7 +50,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                 sendMessage(sender, "&cOnly players can use this command!");
                 return true;
             }
-            if (!sender.hasPermission("smp.forcelock") && !sender.isOp()) {
+            if (!sender.hasPermission("smp.forcelock")) {
                 sendMessage(sender, ChatUtils.PREFIX + ChatUtils.DENIED_COMMAND);
                 return true;
             }
@@ -62,17 +62,50 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                 sendMessage(sender, ChatUtils.PREFIX + "&c" + args[1] + " is not a valid player!");
                 return true;
             }
-            Block targetBlock = player.getTargetBlock(null, 5);
+            Block targetBlock = player.getTargetBlockExact( 5);
             if (!(targetBlock.getState() instanceof Sign sign)) {
                 sendMessage(sender, ChatUtils.PREFIX + "&cMust be a targeting a sign.");
                 return true;
             }
-            sendMessage(sender, ChatUtils.PREFIX + "&aLocking sign for " + args[1]);
             OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(args[1]);
+            sendMessage(sender, ChatUtils.PREFIX + "&7Locking sign for &a" + offlinePlayer.getName());
             sign.getPersistentDataContainer().set(SMPUtils.OWNER_UUID_KEY, PersistentDataType.STRING, offlinePlayer.getUniqueId().toString());
-            sign.getSide(Side.FRONT).setLine(0, "[Locked]");
+            sign.getSide(Side.FRONT).setLine(0, "[LockedV2]");
             sign.getSide(Side.FRONT).setLine(1, offlinePlayer.getName());
+            sign.setWaxed(true);
             sign.update();
+
+        } else if (args[0].equalsIgnoreCase("lockholder")) {
+            if (!(sender instanceof Player player)) {
+                sendMessage(sender, "&cOnly players can use this command!");
+                return true;
+            }
+            if (!sender.hasPermission("smp.lockinspect")) {
+                sendMessage(sender, ChatUtils.PREFIX + ChatUtils.DENIED_COMMAND);
+                return true;
+            }
+
+            Block targetBlock = player.getTargetBlockExact(5);
+            if (!(targetBlock.getState() instanceof Sign sign)) {
+                sendMessage(sender, ChatUtils.PREFIX + "&cMust be a targeting a sign.");
+                return true;
+            }
+            
+            if (sign.getPersistentDataContainer().get(SMPUtils.OWNER_UUID_KEY, PersistentDataType.STRING) == null) {
+                sendMessage(sender, ChatUtils.PREFIX + "&cThis sign doesn't have a lock.");
+                return true;
+            }
+            UUID signOwnerUUID = UUID.fromString(sign.getPersistentDataContainer().get(SMPUtils.OWNER_UUID_KEY, PersistentDataType.STRING)); 
+            
+            OfflinePlayer signOwner = Bukkit.getOfflinePlayer(signOwnerUUID);
+            
+            if (signOwner == null) {
+                sendMessage(sender, ChatUtils.PREFIX + "&cThe sign is locked, but the owner doesn't exist.");
+                return true;
+            }
+            
+            sendMessage(sender, ChatUtils.PREFIX + "&a" + signOwner.getName() + " &7is the owner of this lock.");
+
         } else if (args[0].equalsIgnoreCase("help")) {
             sendMessage(sender, "&8&m------------------------&8&l[&a&lSMP&8&l]&8&m------------------------");
             sendMessage(sender, "&a/smp help &7- Displays this menu");

--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -73,7 +73,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
             sign.getSide(Side.FRONT).setLine(0, "[Locked]");
             sign.getSide(Side.FRONT).setLine(1, offlinePlayer.getName());
             sign.update();
-        }else if (args[0].equalsIgnoreCase("help")) {
+        } else if (args[0].equalsIgnoreCase("help")) {
             sendMessage(sender, "&8&m------------------------&8&l[&a&lSMP&8&l]&8&m------------------------");
             sendMessage(sender, "&a/smp help &7- Displays this menu");
             sendMessage(sender, "&a/smp features &7- Display the unique features of the server");


### PR DESCRIPTION
Added a new command, `/smp forcelock <player name>`. It allows players with Op or the `smp.forcelock` permission to set a sign to a lock for a specific player. Its useful for rolling back griefing problems, due to WorldGuard not handling PersistantDataContainer data.