### PR TITLE
Remove any calculated damage the player might have when they stop gliding

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
@@ -1,11 +1,13 @@
 package plugins.nate.smp.listeners;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import plugins.nate.smp.SMP;
 import plugins.nate.smp.managers.ElytraGlidingTracker;
 
 public class ElytraFallListener implements Listener {
@@ -17,7 +19,18 @@ public class ElytraFallListener implements Listener {
         } else {
             ElytraGlidingTracker.gliding.remove(p);
             ElytraGlidingTracker.lastLocationMap.remove(p);
-            ElytraGlidingTracker.calculatedDamageMap.remove(p);
+
+            //This seems hacky, but is more or less necessary.
+            //PlayerMoveEvent seems to always happen before EntityDamageEvent,
+            //so we schedule calculated damage to get voided next tick. This means
+            //if your elytra breaks mid-air, or you land in water, that no
+            //weird edge cases happen and calculatedDamage is always removed one way
+            //or another.
+            if (ElytraGlidingTracker.calculatedDamageMap.containsKey(p)) {
+                Bukkit.getServer().getScheduler().runTaskLater(SMP.getPlugin(), () -> {
+                    ElytraGlidingTracker.calculatedDamageMap.remove(p);
+                }, 1L);
+            }
         }
     }
 

--- a/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ElytraFallListener.java
@@ -17,6 +17,7 @@ public class ElytraFallListener implements Listener {
         } else {
             ElytraGlidingTracker.gliding.remove(p);
             ElytraGlidingTracker.lastLocationMap.remove(p);
+            ElytraGlidingTracker.calculatedDamageMap.remove(p);
         }
     }
 


### PR DESCRIPTION
Fixes #54.

Does what it says on the tin. This fixes fall damage not happening if you're gliding and your elytra breaks, and a weird scenario described in #54. By not removing this, (before,) it made the fall you would've taken from the elytra be your next fall damage. If you landed in water, you wouldn't take a fall, so your calculated damage wouldn't apply until your next fall.