### PR TITLE
Add extra duration fireworks with stars

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/ExpandedRocketCraftingListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ExpandedRocketCraftingListener.java
@@ -1,0 +1,49 @@
+package plugins.nate.smp.listeners;
+
+import org.bukkit.FireworkEffect;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.FireworkEffectMeta;
+import org.bukkit.inventory.meta.FireworkMeta;
+
+public class ExpandedRocketCraftingListener implements Listener {
+    @EventHandler
+    public void onPrepareCrafting(PrepareItemCraftEvent e) {
+        ItemStack result = e.getInventory().getResult();
+        if (result == null || result.getType() != Material.FIREWORK_ROCKET) {
+            return;
+        }
+
+        FireworkMeta resultingRocketMeta = (FireworkMeta) result.getItemMeta();
+        if (resultingRocketMeta == null) {
+            return;
+        }
+
+        //If its power is less than 4, we're dealing with vanilla rockets. No change necessary!
+        if (resultingRocketMeta.getPower() < 4) {
+            return;
+        }
+
+        for (ItemStack item : e.getInventory().getMatrix()) {
+            if (item == null || item.getType() != Material.FIREWORK_STAR) {
+                continue;
+            }
+
+            FireworkEffectMeta fireworkStarMeta = (FireworkEffectMeta) item.getItemMeta();
+            if (fireworkStarMeta == null) {
+                continue;
+            }
+
+            FireworkEffect effect = fireworkStarMeta.getEffect();
+            if (effect != null) {
+                resultingRocketMeta.addEffect(effect);
+            }
+        }
+
+        result.setItemMeta(resultingRocketMeta);
+        e.getInventory().setResult(result);
+    }
+}

--- a/src/main/java/plugins/nate/smp/managers/RecipeManager.java
+++ b/src/main/java/plugins/nate/smp/managers/RecipeManager.java
@@ -8,33 +8,33 @@ import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.FireworkMeta;
 import plugins.nate.smp.SMP;
 
-import java.util.Map;
-
 public class RecipeManager {
     public static void registerRecipes() {
         registerRocketRecipes();
     }
 
-    private static final Map<String, Integer> rocketIdentifierMap = Map.of(
-            "four_duration_rocket", 4,
-            "five_duration_rocket", 5,
-            "six_duration_rocket", 6,
-            "seven_duration_rocket", 7,
-            "eight_duration_rocket", 8);
-
     private static void registerRocketRecipes() {
-        for (Map.Entry<String, Integer> rocketRecipe : rocketIdentifierMap.entrySet()) {
-            ItemStack longerDurationRocket = new ItemStack(Material.FIREWORK_ROCKET, 3);
-            FireworkMeta meta = (FireworkMeta) longerDurationRocket.getItemMeta();
-            if (meta != null) {
-                meta.setPower(rocketRecipe.getValue());
-            }
-            longerDurationRocket.setItemMeta(meta);
+        //Vanilla supports up to duration 3 rockets by default. Let's support more!
+        for (int power = 4; power <= 8; power++) {
+            for (int stars = 0; stars <= 8 - power; stars++) {
+                ItemStack longerDurationRocket = new ItemStack(Material.FIREWORK_ROCKET, 3);
+                FireworkMeta meta = (FireworkMeta) longerDurationRocket.getItemMeta();
+                if (meta != null) {
+                    meta.setPower(power);
+                }
 
-            ShapelessRecipe recipe = new ShapelessRecipe(new NamespacedKey(SMP.getPlugin(), rocketRecipe.getKey()), longerDurationRocket);
-            recipe.addIngredient(rocketRecipe.getValue(), Material.GUNPOWDER);
-            recipe.addIngredient(Material.PAPER);
-            Bukkit.getServer().addRecipe(recipe);
+                longerDurationRocket.setItemMeta(meta);
+
+                String recipeName = String.format("%d_duration_%d_star_rocket", power, stars);
+                ShapelessRecipe recipe = new ShapelessRecipe(new NamespacedKey(SMP.getPlugin(), recipeName), longerDurationRocket);
+                recipe.addIngredient(power, Material.GUNPOWDER);
+                if (stars > 0) {
+                    recipe.addIngredient(stars, Material.FIREWORK_STAR);
+                }
+
+                recipe.addIngredient(Material.PAPER);
+                Bukkit.getServer().addRecipe(recipe);
+            }
         }
     }
 }

--- a/src/main/java/plugins/nate/smp/utils/EventRegistration.java
+++ b/src/main/java/plugins/nate/smp/utils/EventRegistration.java
@@ -24,5 +24,6 @@ public class EventRegistration {
         pm.registerEvents(new TimberListener(), plugin);
         pm.registerEvents(new AntiEntityGriefListener(), plugin);
         pm.registerEvents(new ElytraFallListener(), plugin);
+        pm.registerEvents(new ExpandedRocketCraftingListener(), plugin);
     }
 }


### PR DESCRIPTION
This PR adds support for extra duration rockets that also include firework stars, so you can have a firework rocket that explodes with a cool pattern up to duration 7 now. (Duration 8 would be all gunpowder.)