### PR TITLE
Created tellers to transfer diamonds into digital diamonds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/groups/public/' }
     maven { url 'https://maven.playpro.com' }
     maven { url 'https://maven.enginehub.org/repo/' }
+    maven { url "https://repo.essentialsx.net/releases" }
 }
 
 dependencies {
@@ -19,6 +20,7 @@ dependencies {
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
     compileOnly 'com.sk89q.worldguard:worldguard-core:7.0.4'
     compileOnly "net.coreprotect:coreprotect:22.2"
+    compileOnly 'net.essentialsx:EssentialsX:2.20.1'
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -112,7 +112,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                     // Storing UUID of the villager it's bound to
                     text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
                     text.setBillboard(Billboard.CENTER);
-                    text.setText("ᴅᴇᴘᴏsɪᴛ ᴅɪᴀᴍᴏɴᴅs (Đ)");
+                    text.setText("ᴅᴇᴘᴏsɪᴛ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
                 });
 
                 sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &adeposit &7teller.");
@@ -130,7 +130,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                     // Storing UUID of the villager it's bound to                    
                     text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
                     text.setBillboard(Billboard.CENTER);
-                    text.setText("ᴡɪᴛʜᴅʀᴀᴡ ᴅɪᴀᴍᴏɴᴅs (Đ)");
+                    text.setText("ᴡɪᴛʜᴅʀᴀᴡ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
                 });
 
                 sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &awithdraw &7teller.");

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -1,0 +1,180 @@
+package plugins.nate.smp.listeners;
+
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.persistence.PersistentDataType;
+
+import com.earth2me.essentials.api.Economy;
+import com.earth2me.essentials.api.NoLoanPermittedException;
+import com.earth2me.essentials.api.UserDoesNotExistException;
+
+import net.ess3.api.MaxMoneyException;
+import plugins.nate.smp.utils.ChatUtils;
+import plugins.nate.smp.utils.SMPUtils;
+
+public class TellerTradeListener implements Listener {
+    private static enum SOUND_EFFECTS {
+        SUCCESS, ERROR, NEUTRAL 
+    };
+    
+    @EventHandler
+    public void onTellerInterract(PlayerInteractEntityEvent event) throws UserDoesNotExistException, NoLoanPermittedException, MaxMoneyException {
+        Entity clickedEntity = event.getRightClicked();
+        if (clickedEntity.getType() != EntityType.VILLAGER) {
+            return;
+        };
+        
+        if (!clickedEntity.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+            return;
+        }
+        event.setCancelled(true);
+        
+        Player player = event.getPlayer();
+        PlayerInventory inventory = player.getInventory();
+        UUID playerUUID = player.getUniqueId();
+        String tellerKey = clickedEntity.getPersistentDataContainer().get(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING); 
+
+        BigDecimal playerBalance = Economy.getMoneyExact(playerUUID);
+        switch (tellerKey.toLowerCase()) {
+            case "withdraw": {
+                if (playerBalance.compareTo(BigDecimal.valueOf(1d)) < 0) {
+                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have enough funds.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+                    return;
+                }
+
+                if (playerBalance.compareTo(BigDecimal.valueOf(9d)) < 0) {
+                    // Adds item to inventory, if it can't then cancel
+                    if (!inventory.addItem(new ItemStack(Material.DIAMOND)).isEmpty()) {
+                        sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
+                        return;
+                    };
+                    Economy.subtract(playerUUID, BigDecimal.valueOf(1));
+
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    
+                    return;
+                }
+
+                if (!inventory.addItem(new ItemStack(Material.DIAMOND_BLOCK)).isEmpty()) {
+                    sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
+                    return;
+                };
+                Economy.subtract(playerUUID, BigDecimal.valueOf(9));
+                
+                sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond block!");
+                playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                
+
+                return;
+            } 
+            case "deposit": {
+                if (inventory.contains(Material.DIAMOND_BLOCK)) {
+                    int diamondIndex = inventory.first(Material.DIAMOND_BLOCK);
+                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND_BLOCK))) {
+                        int itemsHeld = inventory.getItemInMainHand().getAmount();
+                        
+                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld * 9));
+                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
+                        
+                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond block"+ (itemsHeld > 1 ? "s" : "") + "!");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                        return;
+                    }
+                    ItemStack diamondStack = inventory.getItem(diamondIndex);
+                    diamondStack.setAmount(diamondStack.getAmount() - 1);
+                    
+                    inventory.setItem(diamondIndex, diamondStack);
+                    Economy.add(playerUUID, BigDecimal.valueOf(9));
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond block!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    return;
+                } else if (inventory.contains(Material.DIAMOND)) {
+                    int diamondIndex = inventory.first(Material.DIAMOND);
+                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND))) {
+                        int itemsHeld = inventory.getItemInMainHand().getAmount();
+                        
+                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld));
+                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
+                        
+                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond"+ (itemsHeld > 1 ? "s" : "") + "!");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                        return;
+                    }
+                    ItemStack diamondStack = inventory.getItem(diamondIndex);
+                    diamondStack.setAmount(diamondStack.getAmount() - 1);
+
+                    inventory.setItem(diamondIndex, diamondStack);
+                    Economy.add(playerUUID, BigDecimal.valueOf(1));
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    return;
+                } else {
+                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have anything to deposit.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+                }
+                return;
+            }
+            default: {
+                sendMessage(player, ChatUtils.PREFIX + "&cThis teller does not have a valid TELLER_KEY. Contact an admin.");
+                return;
+            }
+        }
+    }
+
+    // Remove the text display linked with the teller
+    @EventHandler
+    public void onTellerDeath(EntityDeathEvent event) {
+        if (event.getEntityType() != EntityType.VILLAGER) {
+            return;
+        }
+
+        LivingEntity teller = event.getEntity();
+        if (!teller.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+            return;
+        };
+        
+        Optional<Entity> textDisplay = teller.getWorld().getNearbyEntities(teller.getLocation().add(0, 2.4, 0), .1, .1, .1)
+            .stream()
+            .filter(entity -> entity instanceof TextDisplay)
+            .filter(entity -> entity.getPersistentDataContainer().has(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING))
+            .filter(entity -> entity.getPersistentDataContainer().get(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING).equals(teller.getUniqueId().toString()))
+            .findFirst();
+
+        if (textDisplay.isPresent()) {
+            textDisplay.get().remove();
+        }
+    }
+
+    private void playSound(Player player, Location location, SOUND_EFFECTS sound) {
+        if (sound == SOUND_EFFECTS.SUCCESS) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_XYLOPHONE, 0.5f, 0f);
+        } else if (sound == SOUND_EFFECTS.NEUTRAL) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_BASEDRUM, 0.5f, 0f);
+        } else if (sound == SOUND_EFFECTS.ERROR) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 0.5f, 0f);
+        }
+    }
+
+}

--- a/src/main/java/plugins/nate/smp/utils/EventRegistration.java
+++ b/src/main/java/plugins/nate/smp/utils/EventRegistration.java
@@ -25,5 +25,6 @@ public class EventRegistration {
         pm.registerEvents(new AntiEntityGriefListener(), plugin);
         pm.registerEvents(new ElytraFallListener(), plugin);
         pm.registerEvents(new ExpandedRocketCraftingListener(), plugin);
+        pm.registerEvents(new TellerTradeListener(), plugin);
     }
 }

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -1,5 +1,17 @@
 package plugins.nate.smp.utils;
 
+import static plugins.nate.smp.utils.ChatUtils.PREFIX;
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
@@ -7,18 +19,13 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
-import org.bukkit.*;
-import org.bukkit.command.CommandSender;
-import org.bukkit.event.HandlerList;
-import org.bukkit.plugin.Plugin;
 import plugins.nate.smp.SMP;
-
-import static plugins.nate.smp.utils.ChatUtils.PREFIX;
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
 
 public class SMPUtils {
     public static final NamespacedKey OWNER_UUID_KEY = new NamespacedKey(SMP.getPlugin(), "ownerUUID");
     public static final NamespacedKey TRADE_LOCKED_KEY = new NamespacedKey(SMP.getPlugin(), "tradeLocked");
+    public static final NamespacedKey TELLER_TYPE_KEY = new NamespacedKey(SMP.getPlugin(), "tellerType");
+    public static final NamespacedKey PARENT_TELLER_KEY = new NamespacedKey(SMP.getPlugin(), "parentTeller");
 
     public static void reloadPlugin(CommandSender sender) {
         SMP smp = SMP.getPlugin();


### PR DESCRIPTION
Added two new commands, they need the `smp.createteller` permission. 
- `/smp teller deposit` Creates a villager with a "Deposit diamonds" text above it. Right clicking it: takes a diamond from the players inventory and adds balance equal to the value of the diamond type. `DIAMOND_BLOCK`s get deposited first, then `DIAMOND`s. If a person is shift right clicking, it will deposit all the diamonds in their hand into the bank.

- `/smp teller withdraw` Creates a villager with a "Withdraw diamonds" text above it. Right clicking it will withdraw 1 `DIAMOND_BLOCK` if they have more than or equal to 9 virtual diamonds. If they have less than 9, it will give a `DIAMOND`.
Players are unable to withdraw if they have a full inventory.
