### PR TITLE
Fixed timber being able to bypass WorldGuarded regions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/groups/public/' }
     maven { url 'https://maven.playpro.com' }
     maven { url 'https://maven.enginehub.org/repo/' }
+    maven { url "https://repo.essentialsx.net/releases" }
 }
 
 dependencies {
@@ -19,6 +20,7 @@ dependencies {
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
     compileOnly 'com.sk89q.worldguard:worldguard-core:7.0.4'
     compileOnly "net.coreprotect:coreprotect:22.2"
+    compileOnly 'net.essentialsx:EssentialsX:2.20.1'
 }
 
 def targetJavaVersion = 17

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
     compileOnly 'com.sk89q.worldguard:worldguard-core:7.0.4'
     compileOnly "net.coreprotect:coreprotect:22.2"
-//    compileOnly 'net.essentialsx:EssentialsX:2.20.1'
     compileOnly "com.github.MilkBowl:VaultAPI:1.7"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
     maven { url 'https://maven.playpro.com' }
     maven { url 'https://maven.enginehub.org/repo/' }
     maven { url "https://repo.essentialsx.net/releases" }
+    maven { url "https://jitpack.io" }
 }
 
 dependencies {
@@ -20,7 +21,8 @@ dependencies {
     compileOnly 'com.sk89q.worldedit:worldedit-bukkit:7.2.14'
     compileOnly 'com.sk89q.worldguard:worldguard-core:7.0.4'
     compileOnly "net.coreprotect:coreprotect:22.2"
-    compileOnly 'net.essentialsx:EssentialsX:2.20.1'
+//    compileOnly 'net.essentialsx:EssentialsX:2.20.1'
+    compileOnly "com.github.MilkBowl:VaultAPI:1.7"
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -21,6 +21,7 @@ public final class SMP extends JavaPlugin {
     private static CoreProtectAPI coreProtect;
 
     public static StateFlag WITHER_EXPLOSIONS;
+    public static StateFlag BANK_FLAG;
 
     public static final Logger logger = Logger.getLogger("Minecraft");
     public final File prefixesFile = new File(getDataFolder() + "/prefixes.yml");
@@ -51,9 +52,13 @@ public final class SMP extends JavaPlugin {
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
         try {
             StateFlag witherExplosionsFlag = new StateFlag("wither-explosions", true);
+            StateFlag bankFlag = new StateFlag("bank", false);
+
             registry.register(witherExplosionsFlag);
+            registry.register(bankFlag);
 
             WITHER_EXPLOSIONS = witherExplosionsFlag;
+            BANK_FLAG = bankFlag;
         } catch (FlagConflictException ignored) {}
     }
 

--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -11,10 +11,7 @@ import plugins.nate.smp.managers.ElytraGlidingTracker;
 import plugins.nate.smp.managers.EnchantmentManager;
 import plugins.nate.smp.managers.RecipeManager;
 import plugins.nate.smp.managers.TrustManager;
-import plugins.nate.smp.utils.CommandRegistration;
-import plugins.nate.smp.utils.DependencyUtils;
-import plugins.nate.smp.utils.EventRegistration;
-import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.*;
 
 import java.io.File;
 import java.util.logging.Logger;
@@ -40,6 +37,7 @@ public final class SMP extends JavaPlugin {
 
         DependencyUtils.checkDependencies();
         EventRegistration.registerEvents(this);
+        VaultUtils.setupEconomy(this);
         CommandRegistration.registerCommands(this);
         EnchantmentManager.registerEnchants();
         RecipeManager.registerRecipes();
@@ -66,6 +64,7 @@ public final class SMP extends JavaPlugin {
     public static CoreProtectAPI getCoreProtect() {
         return coreProtect;
     }
+
 
 }
 

--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -1,9 +1,5 @@
 package plugins.nate.smp;
 
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
-import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import net.coreprotect.CoreProtectAPI;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -19,9 +15,6 @@ import java.util.logging.Logger;
 public final class SMP extends JavaPlugin {
     private static SMP plugin;
     private static CoreProtectAPI coreProtect;
-
-    public static StateFlag WITHER_EXPLOSIONS;
-    public static StateFlag BANK_FLAG;
 
     public static final Logger logger = Logger.getLogger("Minecraft");
     public final File prefixesFile = new File(getDataFolder() + "/prefixes.yml");
@@ -48,18 +41,7 @@ public final class SMP extends JavaPlugin {
     @Override
     public void onLoad() {
         super.onLoad();
-
-        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
-        try {
-            StateFlag witherExplosionsFlag = new StateFlag("wither-explosions", true);
-            StateFlag bankFlag = new StateFlag("bank", false);
-
-            registry.register(witherExplosionsFlag);
-            registry.register(bankFlag);
-
-            WITHER_EXPLOSIONS = witherExplosionsFlag;
-            BANK_FLAG = bankFlag;
-        } catch (FlagConflictException ignored) {}
+        WorldGuardUtils.registerFlags();
     }
 
     public static SMP getPlugin() {

--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -1,36 +1,26 @@
 package plugins.nate.smp.commands;
 
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
-import org.bukkit.block.Container;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.TextDisplay;
-import org.bukkit.entity.Villager;
-import org.bukkit.entity.Display.Billboard;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-
-import plugins.nate.smp.listeners.ChestLockListener;
 import plugins.nate.smp.managers.TrustManager;
 import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.TellerUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
 
 public class SMPCommand implements CommandExecutor, TabCompleter {
     private static final Set<String> VALID_SUBCOMMANDS = Set.of("help", "features", "reload", "forcelock", "lockholder", "teller", "trust", "untrust", "trustlist", "lock", "unlock");
@@ -92,50 +82,29 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                 sendMessage(sender, "&cOnly players can use this command!");
                 return true;
             }
+
             if (!sender.hasPermission("smp.createteller")) {
                 sendMessage(sender, ChatUtils.PREFIX + ChatUtils.DENIED_COMMAND);
                 return true;
             }
+
             if (args.length == 1) {
                 sendMessage(sender, ChatUtils.PREFIX + "&cUsage: /smp teller (deposit/withdraw)");
                 return true;
             }
+
             if (args[1].equalsIgnoreCase("deposit")) {
-                Entity teller = player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
-                    villager.getPersistentDataContainer().set(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING, "DEPOSIT");
-                    villager.setRotation(player.getLocation().getYaw(), player.getLocation().getPitch());
-                    villager.setInvulnerable(true);
-                    villager.setAI(false);
-                });
-
-                player.getWorld().spawn(player.getLocation().add(0, 2.4, 0), TextDisplay.class, (text) -> {
-                    // Storing UUID of the villager it's bound to
-                    text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
-                    text.setBillboard(Billboard.CENTER);
-                    text.setText("ᴅᴇᴘᴏsɪᴛ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
-                });
-
+                TellerUtils.createDepositTeller(player);
                 sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &adeposit &7teller.");
                 return true;
             }
+
             if (args[1].equalsIgnoreCase("withdraw")) {
-                Entity teller = player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
-                    villager.getPersistentDataContainer().set(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING, "WITHDRAW");
-                    villager.setRotation(player.getLocation().getYaw(), player.getLocation().getPitch());
-                    villager.setInvulnerable(true);
-                    villager.setAI(false);
-                });
-
-                player.getWorld().spawn(player.getLocation().add(0, 2.4, 0), TextDisplay.class, (text) -> {
-                    // Storing UUID of the villager it's bound to                    
-                    text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
-                    text.setBillboard(Billboard.CENTER);
-                    text.setText("ᴡɪᴛʜᴅʀᴀᴡ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
-                });
-
+                TellerUtils.createWithdrawTeller(player);
                 sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &awithdraw &7teller.");
                 return true;
             }
+
             sendMessage(sender, ChatUtils.PREFIX + "&cUsage: /smp teller (deposit/withdraw)");
             return true;
         } else if (args[0].equalsIgnoreCase("lockholder")) {

--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -1,27 +1,40 @@
 package plugins.nate.smp.commands;
 
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
-import org.bukkit.command.*;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.Display.Billboard;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
+
+import plugins.nate.smp.listeners.ChestLockListener;
 import plugins.nate.smp.managers.TrustManager;
 import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
 public class SMPCommand implements CommandExecutor, TabCompleter {
-    private static final Set<String> VALID_SUBCOMMANDS = Set.of("help", "features", "reload", "forcelock", "lockholder", "trust", "untrust", "trustlist", "lock", "unlock");
-
+    private static final Set<String> VALID_SUBCOMMANDS = Set.of("help", "features", "reload", "forcelock", "lockholder", "teller", "trust", "untrust", "trustlist", "lock", "unlock");
+    
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
         if (args.length == 0) {
@@ -74,7 +87,57 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
             sign.getSide(Side.FRONT).setLine(1, offlinePlayer.getName());
             sign.setWaxed(true);
             sign.update();
+        } else if (args[0].equalsIgnoreCase("teller")) {
+            if (!(sender instanceof Player player)) {
+                sendMessage(sender, "&cOnly players can use this command!");
+                return true;
+            }
+            if (!sender.hasPermission("smp.createteller")) {
+                sendMessage(sender, ChatUtils.PREFIX + ChatUtils.DENIED_COMMAND);
+                return true;
+            }
+            if (args.length == 1) {
+                sendMessage(sender, ChatUtils.PREFIX + "&cUsage: /smp teller (deposit/withdraw)");
+                return true;
+            }
+            if (args[1].equalsIgnoreCase("deposit")) {
+                Entity teller = player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
+                    villager.getPersistentDataContainer().set(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING, "DEPOSIT");
+                    villager.setRotation(player.getLocation().getYaw(), player.getLocation().getPitch());
+                    villager.setInvulnerable(true);
+                    villager.setAI(false);
+                });
 
+                player.getWorld().spawn(player.getLocation().add(0, 2.4, 0), TextDisplay.class, (text) -> {
+                    // Storing UUID of the villager it's bound to
+                    text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
+                    text.setBillboard(Billboard.CENTER);
+                    text.setText("ᴅᴇᴘᴏsɪᴛ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
+                });
+
+                sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &adeposit &7teller.");
+                return true;
+            }
+            if (args[1].equalsIgnoreCase("withdraw")) {
+                Entity teller = player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
+                    villager.getPersistentDataContainer().set(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING, "WITHDRAW");
+                    villager.setRotation(player.getLocation().getYaw(), player.getLocation().getPitch());
+                    villager.setInvulnerable(true);
+                    villager.setAI(false);
+                });
+
+                player.getWorld().spawn(player.getLocation().add(0, 2.4, 0), TextDisplay.class, (text) -> {
+                    // Storing UUID of the villager it's bound to                    
+                    text.getPersistentDataContainer().set(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
+                    text.setBillboard(Billboard.CENTER);
+                    text.setText("ᴡɪᴛʜᴅʀᴀᴡ ᴅɪᴀᴍᴏɴᴅs ("+ '\u00D0' + ")");
+                });
+
+                sendMessage(sender, ChatUtils.PREFIX + "&7Spawning a &awithdraw &7teller.");
+                return true;
+            }
+            sendMessage(sender, ChatUtils.PREFIX + "&cUsage: /smp teller (deposit/withdraw)");
+            return true;
         } else if (args[0].equalsIgnoreCase("lockholder")) {
             if (!(sender instanceof Player player)) {
                 sendMessage(sender, "&cOnly players can use this command!");

--- a/src/main/java/plugins/nate/smp/guis/TellerDepositGUI.java
+++ b/src/main/java/plugins/nate/smp/guis/TellerDepositGUI.java
@@ -1,0 +1,27 @@
+package plugins.nate.smp.guis;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Inventory;
+import plugins.nate.smp.SMP;
+import plugins.nate.smp.interfaces.CustomGUI;
+
+public class TellerDepositGUI implements CustomGUI {
+    private final Inventory inventory;
+    private final NamespacedKey key;
+
+    public TellerDepositGUI() {
+        this.key = new NamespacedKey(SMP.getPlugin(), "deposit_gui");
+        this.inventory = Bukkit.createInventory(this, 27, "Deposit Diamonds");
+    }
+
+    @Override
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+}

--- a/src/main/java/plugins/nate/smp/interfaces/CustomGUI.java
+++ b/src/main/java/plugins/nate/smp/interfaces/CustomGUI.java
@@ -1,0 +1,15 @@
+package plugins.nate.smp.interfaces;
+
+import org.bukkit.ChatColor;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public interface CustomGUI extends InventoryHolder {
+    Inventory getInventory();
+    NamespacedKey getKey();
+
+    default String colorize(String message) {
+        return ChatColor.translateAlternateColorCodes('&', message);
+    }
+}

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -1,0 +1,180 @@
+package plugins.nate.smp.listeners;
+
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.persistence.PersistentDataType;
+
+import com.earth2me.essentials.api.Economy;
+import com.earth2me.essentials.api.NoLoanPermittedException;
+import com.earth2me.essentials.api.UserDoesNotExistException;
+
+import net.ess3.api.MaxMoneyException;
+import plugins.nate.smp.utils.ChatUtils;
+import plugins.nate.smp.utils.SMPUtils;
+
+public class TellerTradeListener implements Listener {
+    private static enum SOUND_EFFECTS {
+        SUCCESS, ERROR, NEUTRAL 
+    };
+    
+    @EventHandler
+    public void onTellerInterract(PlayerInteractEntityEvent event) throws UserDoesNotExistException, NoLoanPermittedException, MaxMoneyException {
+        Entity clickedEntity = event.getRightClicked();
+        if (clickedEntity.getType() != EntityType.VILLAGER) {
+            return;
+        };
+        
+        if (!clickedEntity.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+            return;
+        }
+        event.setCancelled(true);
+        
+        Player player = event.getPlayer();
+        PlayerInventory inventory = player.getInventory();
+        UUID playerUUID = player.getUniqueId();
+        String tellerKey = clickedEntity.getPersistentDataContainer().get(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING); 
+
+        BigDecimal playerBalance = Economy.getMoneyExact(playerUUID);
+        switch (tellerKey.toLowerCase()) {
+            case "withdraw": {
+                if (playerBalance.compareTo(BigDecimal.valueOf(1d)) < 0) {
+                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have enough funds.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+                    return;
+                }
+
+                if (playerBalance.compareTo(BigDecimal.valueOf(9d)) < 0) {
+                    // Adds item to inventory, if it can't then cancel
+                    if (!inventory.addItem(new ItemStack(Material.DIAMOND)).isEmpty()) {
+                        sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
+                        return;
+                    };
+                    Economy.subtract(playerUUID, BigDecimal.valueOf(1));
+
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    
+                    return;
+                }
+
+                if (!inventory.addItem(new ItemStack(Material.DIAMOND_BLOCK)).isEmpty()) {
+                    sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
+                    return;
+                };
+                Economy.subtract(playerUUID, BigDecimal.valueOf(9));
+                
+                sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond block!");
+                playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                
+
+                return;
+            } 
+            case "deposit": {
+                if (inventory.contains(Material.DIAMOND_BLOCK)) {
+                    int diamondIndex = inventory.first(Material.DIAMOND_BLOCK);
+                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND_BLOCK))) {
+                        int itemsHeld = inventory.getItemInMainHand().getAmount();
+                        
+                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld * 9));
+                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
+                        
+                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond block"+ (itemsHeld > 1 ? "s" : "") + "!");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                        return;
+                    }
+                    ItemStack diamondStack = inventory.getItem(diamondIndex);
+                    diamondStack.setAmount(diamondStack.getAmount() - 1);
+                    
+                    inventory.setItem(diamondIndex, diamondStack);
+                    Economy.add(playerUUID, BigDecimal.valueOf(9));
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond block!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    return;
+                } else if (inventory.contains(Material.DIAMOND)) {
+                    int diamondIndex = inventory.first(Material.DIAMOND);
+                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND))) {
+                        int itemsHeld = inventory.getItemInMainHand().getAmount();
+                        
+                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld));
+                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
+                        
+                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond"+ (itemsHeld > 1 ? "s" : "") + "!");
+                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                        return;
+                    }
+                    ItemStack diamondStack = inventory.getItem(diamondIndex);
+                    diamondStack.setAmount(diamondStack.getAmount() - 1);
+
+                    inventory.setItem(diamondIndex, diamondStack);
+                    Economy.add(playerUUID, BigDecimal.valueOf(1));
+                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond!");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+                    return;
+                } else {
+                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have anything to deposit.");
+                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+                }
+                return;
+            }
+            default: {
+                sendMessage(player, ChatUtils.PREFIX + "&cThis teller does not have a valid TELLER_KEY. Contact an admin.");
+                return;
+            }
+        }
+    }
+
+    // Remove the text display linked with the teller
+    @EventHandler
+    public void onTellerDeath(EntityDeathEvent event) {
+        if (event.getEntityType() != EntityType.VILLAGER) {
+            return;
+        }
+
+        LivingEntity teller = event.getEntity();
+        if (!teller.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+            return;
+        };
+        
+        Optional<Entity> textDisplay = teller.getWorld().getNearbyEntities(teller.getLocation().add(0, 2.4, 0), .1, .1, .1)
+            .stream()
+            .filter(entity -> entity instanceof TextDisplay)
+            .filter(entity -> entity.getPersistentDataContainer().has(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING))
+            .filter(entity -> entity.getPersistentDataContainer().get(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING).equals(teller.getUniqueId().toString()))
+            .findFirst();
+
+        if (textDisplay.isPresent()) {
+            textDisplay.get().remove();
+        }
+    }
+
+    private void playSound(Player player, Location location, SOUND_EFFECTS sound) {
+        if (sound == SOUND_EFFECTS.SUCCESS) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_XYLOPHONE, 0.5f, 0f);
+        } else if (sound == SOUND_EFFECTS.NEUTRAL) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_BASEDRUM, 0.5f, 0f);
+        } else if (sound == SOUND_EFFECTS.ERROR) {
+            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 0.5f, 0f);
+        }
+    }
+
+}

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -41,7 +41,7 @@ public class TellerTradeListener implements Listener {
     @EventHandler
     public void onTellerInteract(PlayerInteractEntityEvent event) {
         Entity clickedEntity = event.getRightClicked();
-        if (clickedEntity.getType() != EntityType.VILLAGER || TellerUtils.isTeller(clickedEntity)) {
+        if (clickedEntity.getType() != EntityType.VILLAGER || !TellerUtils.isTeller(clickedEntity)) {
             return;
         }
 

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -183,7 +183,7 @@ public class TellerTradeListener implements Listener {
             if (clickedItem != null && clickedItem.getType() != Material.DIAMOND && clickedItem.getType() != Material.DIAMOND_BLOCK) {
                 event.setCancelled(true);
                 sendMessage(player, PREFIX + "&cYou can only deposit diamonds or diamond blocks.");
-                playSound(player, player.getLocation(), SOUND_EFFECTS.ERROR);
+                playSound(player, SOUND_EFFECTS.ERROR);
             }
         }
     }
@@ -196,7 +196,8 @@ public class TellerTradeListener implements Listener {
         double playerBalance = VaultUtils.getBalance(player);
 
         if (playerBalance < 1.0) {
-            // Send insufficient funds message
+            sendMessage(player, PREFIX + "&cYou have no funds to withdraw!");
+            playSound(player, SOUND_EFFECTS.ERROR);
             return;
         }
 
@@ -225,7 +226,7 @@ public class TellerTradeListener implements Listener {
 
         if (!player.getInventory().addItem(withdrawalItem).isEmpty()) {
             sendMessage(player, PREFIX + "&cYou don't have enough inventory space.");
-            playSound(player, player.getLocation(), SOUND_EFFECTS.ERROR);
+            playSound(player, SOUND_EFFECTS.ERROR);
             return;
         }
 
@@ -241,13 +242,13 @@ public class TellerTradeListener implements Listener {
     * Helper methods
     * */
 
-    private void playSound(Player player, Location location, SOUND_EFFECTS sound) {
+    private void playSound(Player player, SOUND_EFFECTS sound) {
         if (sound == SOUND_EFFECTS.SUCCESS) {
-            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_XYLOPHONE, 0.5f, 0f);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_XYLOPHONE, 0.5f, 0f);
         } else if (sound == SOUND_EFFECTS.NEUTRAL) {
-            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_BASEDRUM, 0.5f, 0f);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASEDRUM, 0.5f, 0f);
         } else if (sound == SOUND_EFFECTS.ERROR) {
-            player.playSound(location, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 0.5f, 0f);
+            player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 0.5f, 0f);
         }
     }
 

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -88,6 +88,10 @@ public class TellerTradeListener implements Listener {
         }
     }
 
+    /*
+    * Handlers player action bar when moving within a region with the bank allow flag
+    * */
+
     @EventHandler
     public void onPlayerMoveIntoBankRegion(PlayerMoveEvent event) {
         Player player = event.getPlayer();
@@ -110,8 +114,9 @@ public class TellerTradeListener implements Listener {
 
         if (isBankRegion) {
             double balance = VaultUtils.econ.getBalance(player);
+            String formattedBalance = String.format("%.2f", balance);
 
-            createActionBar(player, "&7Balance: &a" + balance + CURRENCY_SYMBOL);
+            createActionBar(player, "&7Balance: &a" + formattedBalance + CURRENCY_SYMBOL);
         } else {
             player.sendTitle("", "", 0, 0, 0);
         }
@@ -120,6 +125,7 @@ public class TellerTradeListener implements Listener {
     /*
      * Methods for handling deposits
      * */
+
     private void handleDeposit(Player player) {
         player.openInventory(new TellerDepositGUI().getInventory());
     }

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -20,7 +20,6 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataType;
 import org.joml.Math;
 import plugins.nate.smp.SMP;
@@ -37,26 +36,19 @@ import static plugins.nate.smp.utils.TellerUtils.CURRENCY_SYMBOL;
 
 
 public class TellerTradeListener implements Listener {
-    private enum SOUND_EFFECTS {
-        SUCCESS, ERROR, NEUTRAL 
-    }
+    private enum SOUND_EFFECTS { SUCCESS, ERROR, NEUTRAL }
     
     @EventHandler
     public void onTellerInteract(PlayerInteractEntityEvent event) {
         Entity clickedEntity = event.getRightClicked();
-        if (clickedEntity.getType() != EntityType.VILLAGER) {
+        if (clickedEntity.getType() != EntityType.VILLAGER || TellerUtils.isTeller(clickedEntity)) {
             return;
         }
 
-        if (!clickedEntity.getPersistentDataContainer().has(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
-            return;
-        }
         event.setCancelled(true);
 
         Player player = event.getPlayer();
-        PlayerInventory inventory = player.getInventory();
-        String tellerKey = clickedEntity.getPersistentDataContainer().get(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING);
-
+        String tellerKey = TellerUtils.getTellerKey(clickedEntity);
 
         if (tellerKey == null || tellerKey.equals("")) {
             SMPUtils.severe(player.getName() + " tried to interact with a null teller at location X: " +

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -1,19 +1,9 @@
 package plugins.nate.smp.listeners;
 
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
-import java.math.BigDecimal;
-import java.util.Optional;
-import java.util.UUID;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.TextDisplay;
+import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -21,125 +11,41 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataType;
-
-import com.earth2me.essentials.api.Economy;
-import com.earth2me.essentials.api.NoLoanPermittedException;
-import com.earth2me.essentials.api.UserDoesNotExistException;
-
-import net.ess3.api.MaxMoneyException;
 import plugins.nate.smp.utils.ChatUtils;
-import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.TellerUtils;
+import plugins.nate.smp.utils.VaultUtils;
+
+import java.util.Optional;
+
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
 
 public class TellerTradeListener implements Listener {
-    private static enum SOUND_EFFECTS {
+    private enum SOUND_EFFECTS {
         SUCCESS, ERROR, NEUTRAL 
-    };
+    }
     
     @EventHandler
-    public void onTellerInterract(PlayerInteractEntityEvent event) throws UserDoesNotExistException, NoLoanPermittedException, MaxMoneyException {
+    public void onTellerInterract(PlayerInteractEntityEvent event) {
         Entity clickedEntity = event.getRightClicked();
         if (clickedEntity.getType() != EntityType.VILLAGER) {
             return;
-        };
-        
-        if (!clickedEntity.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+        }
+
+        if (!clickedEntity.getPersistentDataContainer().has(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
             return;
         }
         event.setCancelled(true);
-        
+
         Player player = event.getPlayer();
         PlayerInventory inventory = player.getInventory();
-        UUID playerUUID = player.getUniqueId();
-        String tellerKey = clickedEntity.getPersistentDataContainer().get(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING); 
+        String tellerKey = clickedEntity.getPersistentDataContainer().get(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING);
 
-        BigDecimal playerBalance = Economy.getMoneyExact(playerUUID);
+        double playerBalance = VaultUtils.econ.getBalance(player);
         switch (tellerKey.toLowerCase()) {
-            case "withdraw": {
-                if (playerBalance.compareTo(BigDecimal.valueOf(1d)) < 0) {
-                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have enough funds.");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
-                    return;
-                }
-
-                if (playerBalance.compareTo(BigDecimal.valueOf(9d)) < 0) {
-                    // Adds item to inventory, if it can't then cancel
-                    if (!inventory.addItem(new ItemStack(Material.DIAMOND)).isEmpty()) {
-                        sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
-                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
-                        return;
-                    };
-                    Economy.subtract(playerUUID, BigDecimal.valueOf(1));
-
-                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond!");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                    
-                    return;
-                }
-
-                if (!inventory.addItem(new ItemStack(Material.DIAMOND_BLOCK)).isEmpty()) {
-                    sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
-                    return;
-                };
-                Economy.subtract(playerUUID, BigDecimal.valueOf(9));
-                
-                sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully withdrew one diamond block!");
-                playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                
-
-                return;
-            } 
-            case "deposit": {
-                if (inventory.contains(Material.DIAMOND_BLOCK)) {
-                    int diamondIndex = inventory.first(Material.DIAMOND_BLOCK);
-                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND_BLOCK))) {
-                        int itemsHeld = inventory.getItemInMainHand().getAmount();
-                        
-                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld * 9));
-                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
-                        
-                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond block"+ (itemsHeld > 1 ? "s" : "") + "!");
-                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                        return;
-                    }
-                    ItemStack diamondStack = inventory.getItem(diamondIndex);
-                    diamondStack.setAmount(diamondStack.getAmount() - 1);
-                    
-                    inventory.setItem(diamondIndex, diamondStack);
-                    Economy.add(playerUUID, BigDecimal.valueOf(9));
-                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond block!");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                    return;
-                } else if (inventory.contains(Material.DIAMOND)) {
-                    int diamondIndex = inventory.first(Material.DIAMOND);
-                    if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(new ItemStack(Material.DIAMOND))) {
-                        int itemsHeld = inventory.getItemInMainHand().getAmount();
-                        
-                        Economy.add(playerUUID, BigDecimal.valueOf(itemsHeld));
-                        inventory.setItemInMainHand(new ItemStack(Material.AIR));
-                        
-                        sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited " + itemsHeld + " diamond"+ (itemsHeld > 1 ? "s" : "") + "!");
-                        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                        return;
-                    }
-                    ItemStack diamondStack = inventory.getItem(diamondIndex);
-                    diamondStack.setAmount(diamondStack.getAmount() - 1);
-
-                    inventory.setItem(diamondIndex, diamondStack);
-                    Economy.add(playerUUID, BigDecimal.valueOf(1));
-                    sendMessage(player, ChatUtils.PREFIX + "&aSuccesfully deposited one diamond!");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
-                    return;
-                } else {
-                    sendMessage(player, ChatUtils.PREFIX + "&7You don't have anything to deposit.");
-                    playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
-                }
-                return;
-            }
-            default: {
-                sendMessage(player, ChatUtils.PREFIX + "&cThis teller does not have a valid TELLER_KEY. Contact an admin.");
-                return;
-            }
+            case "withdraw" -> handleWithdraw(player, inventory, playerBalance, clickedEntity);
+            case "deposit" -> handleDeposit(player, inventory, clickedEntity);
+            default -> sendMessage(player, ChatUtils.PREFIX + "&cThis teller does not have a valid TELLER_KEY. Contact an admin.");
         }
     }
 
@@ -151,15 +57,15 @@ public class TellerTradeListener implements Listener {
         }
 
         LivingEntity teller = event.getEntity();
-        if (!teller.getPersistentDataContainer().has(SMPUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
+        if (!teller.getPersistentDataContainer().has(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING)) {
             return;
         };
         
         Optional<Entity> textDisplay = teller.getWorld().getNearbyEntities(teller.getLocation().add(0, 2.4, 0), .1, .1, .1)
             .stream()
             .filter(entity -> entity instanceof TextDisplay)
-            .filter(entity -> entity.getPersistentDataContainer().has(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING))
-            .filter(entity -> entity.getPersistentDataContainer().get(SMPUtils.PARENT_TELLER_KEY, PersistentDataType.STRING).equals(teller.getUniqueId().toString()))
+            .filter(entity -> entity.getPersistentDataContainer().has(TellerUtils.PARENT_TELLER_KEY, PersistentDataType.STRING))
+            .filter(entity -> entity.getPersistentDataContainer().get(TellerUtils.PARENT_TELLER_KEY, PersistentDataType.STRING).equals(teller.getUniqueId().toString()))
             .findFirst();
 
         if (textDisplay.isPresent()) {
@@ -174,6 +80,74 @@ public class TellerTradeListener implements Listener {
             player.playSound(location, Sound.BLOCK_NOTE_BLOCK_BASEDRUM, 0.5f, 0f);
         } else if (sound == SOUND_EFFECTS.ERROR) {
             player.playSound(location, Sound.BLOCK_NOTE_BLOCK_DIDGERIDOO, 0.5f, 0f);
+        }
+    }
+
+    private void handleWithdraw(Player player, PlayerInventory inventory, double playerBalance, Entity clickedEntity) {
+        if (playerBalance < 1.0) {
+            sendInsufficientFundsMessage(player, clickedEntity);
+            return;
+        }
+
+        ItemStack withdrawalItem = (playerBalance < 9.0) ? new ItemStack(Material.DIAMOND) : new ItemStack(Material.DIAMOND_BLOCK);
+        double amountToWithdraw = (playerBalance < 9.0) ? 1.0 : 9.0;
+
+        if (!inventory.addItem(withdrawalItem).isEmpty()) {
+            sendMessage(player, ChatUtils.PREFIX + "&cYou don't have enough inventory space.");
+            playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.ERROR);
+            return;
+        }
+
+        VaultUtils.econ.withdrawPlayer(player, amountToWithdraw);
+        sendSuccessMessage(player, clickedEntity, "withdraw", amountToWithdraw);
+    }
+
+    private void handleDeposit(Player player, PlayerInventory inventory, Entity clickedEntity) {
+        Material depositMaterial = inventory.contains(Material.DIAMOND_BLOCK) ? Material.DIAMOND_BLOCK : Material.DIAMOND;
+        if (!inventory.contains(depositMaterial)) {
+            sendMessage(player, ChatUtils.PREFIX + "&7You don't have anything to deposit.");
+            playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+            return;
+        }
+
+        int diamondIndex = inventory.first(depositMaterial);
+        ItemStack diamondStack = inventory.getItem(diamondIndex);
+        int amountToDeposit = depositMaterial == Material.DIAMOND_BLOCK ? diamondStack.getAmount() * 9 : diamondStack.getAmount();
+
+        if (player.isSneaking() && inventory.getItemInMainHand().isSimilar(diamondStack)) {
+            inventory.setItemInMainHand(new ItemStack(Material.AIR));
+        } else {
+            diamondStack.setAmount(diamondStack.getAmount() - 1);
+            inventory.setItem(diamondIndex, diamondStack);
+            amountToDeposit = depositMaterial == Material.DIAMOND_BLOCK ? 9 : 1;
+        }
+
+        VaultUtils.econ.depositPlayer(player, amountToDeposit);
+        sendSuccessMessage(player, clickedEntity, "deposit", amountToDeposit);
+    }
+
+    private void sendInsufficientFundsMessage(Player player, Entity clickedEntity) {
+        sendMessage(player, ChatUtils.PREFIX + "&7You don't have enough funds.");
+        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.NEUTRAL);
+    }
+
+    private void sendSuccessMessage(Player player, Entity clickedEntity, String action, double amount) {
+        String message = action.equals("withdraw") ?
+                "&aSuccessfully withdrew " + formatAmount(amount) :
+                "&aSuccessfully deposited " + formatAmount(amount);
+        sendMessage(player, ChatUtils.PREFIX + message);
+        playSound(player, clickedEntity.getLocation(), SOUND_EFFECTS.SUCCESS);
+    }
+
+    private String formatAmount(double amount) {
+        int truncatedAmount = (int) amount;
+
+        if (truncatedAmount == 1.0) {
+            return "one diamond";
+        } else if (truncatedAmount == 9.0) {
+            return "one diamond block";
+        } else {
+            return truncatedAmount + " diamonds";
         }
     }
 

--- a/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/TellerTradeListener.java
@@ -22,11 +22,11 @@ import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.joml.Math;
-import plugins.nate.smp.SMP;
 import plugins.nate.smp.guis.TellerDepositGUI;
 import plugins.nate.smp.utils.SMPUtils;
 import plugins.nate.smp.utils.TellerUtils;
 import plugins.nate.smp.utils.VaultUtils;
+import plugins.nate.smp.utils.WorldGuardUtils;
 
 import java.util.HashMap;
 import java.util.Optional;
@@ -110,7 +110,7 @@ public class TellerTradeListener implements Listener {
         BlockVector3 position = BlockVector3.at(loc.getX(), loc.getY(), loc.getZ());
 
         ApplicableRegionSet regionSet = regionManager.getApplicableRegions(position);
-        boolean isBankRegion = regionSet.queryState(null, SMP.BANK_FLAG) == StateFlag.State.ALLOW;
+        boolean isBankRegion = regionSet.queryState(null, WorldGuardUtils.BANK_FLAG) == StateFlag.State.ALLOW;
 
         if (isBankRegion) {
             double balance = VaultUtils.econ.getBalance(player);

--- a/src/main/java/plugins/nate/smp/listeners/WitherExplosionListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/WitherExplosionListener.java
@@ -5,8 +5,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import plugins.nate.smp.SMP;
-import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.WorldGuardUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -17,7 +16,7 @@ public class WitherExplosionListener implements Listener {
         if (event.getEntityType() == EntityType.WITHER || event.getEntityType() == EntityType.WITHER_SKULL) {
             List<Block> toRemove = event.blockList().stream()
                     .filter(Objects::nonNull)
-                    .filter(block -> !SMPUtils.isFlagAllowedAtLocation(SMP.WITHER_EXPLOSIONS, block.getLocation()))
+                    .filter(block -> !WorldGuardUtils.isFlagAllowedAtLocation(WorldGuardUtils.WITHER_EXPLOSIONS, block.getLocation()))
                     .toList();
 
             event.blockList().removeAll(toRemove);

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -1,6 +1,11 @@
 package plugins.nate.smp.listeners.enchantments;
 
-import net.coreprotect.CoreProtectAPI;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -11,18 +16,21 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import plugins.nate.smp.SMP;
 import plugins.nate.smp.managers.EnchantmentManager;
-import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.WorldGuardUtils;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static plugins.nate.smp.utils.ChatUtils.PREFIX;
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
 
 public class TimberListener implements Listener {
+    private static final Set<StateFlag> antiBuildFlags = new HashSet<>();
+    static {
+        antiBuildFlags.add(Flags.BUILD);
+        antiBuildFlags.add(Flags.BLOCK_BREAK);
+    }
+
     private static final int MAX_BLOCKS = 192;
 
 
@@ -30,6 +38,8 @@ public class TimberListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
+
+
 
         if (!itemInHand.containsEnchantment(EnchantmentManager.ENCHANTMENTS.get("timber"))) {
             return;
@@ -68,6 +78,18 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
+        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(block.getLocation().getWorld()));
+
+        ProtectedRegion region = regionManager.getRegion("spawn");
+
+        if (region == null) {
+            return;
+        }
+
+        if (WorldGuardUtils.hasFlags(region, antiBuildFlags) && region.contains(block.getX(), block.getY(), block.getZ())) {
+            return;
+        }
+
         if (blocksDestroyed.get() >= MAX_BLOCKS || !isLog(block.getType()) || block.getType() == Material.AIR || checkedBlocks.contains(block)) {
             return;
         }

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -1,11 +1,6 @@
 package plugins.nate.smp.listeners.enchantments;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -25,11 +20,6 @@ import java.util.stream.Collectors;
 
 
 public class TimberListener implements Listener {
-    private static final Set<StateFlag> antiBuildFlags = new HashSet<>();
-    static {
-        antiBuildFlags.add(Flags.BUILD);
-        antiBuildFlags.add(Flags.BLOCK_BREAK);
-    }
 
     private static final int MAX_BLOCKS = 192;
 
@@ -38,8 +28,6 @@ public class TimberListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
-
-
 
         if (!itemInHand.containsEnchantment(EnchantmentManager.ENCHANTMENTS.get("timber"))) {
             return;
@@ -78,15 +66,7 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
-        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(block.getLocation().getWorld()));
-
-        ProtectedRegion region = regionManager.getRegion("spawn");
-
-        if (region == null) {
-            return;
-        }
-
-        if (WorldGuardUtils.hasFlags(region, antiBuildFlags) && region.contains(block.getX(), block.getY(), block.getZ())) {
+        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.BANK_FLAG, StateFlag.State.DENY)) {
             return;
         }
 

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -66,7 +66,7 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
-        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.BANK_FLAG, StateFlag.State.DENY)) {
+        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.DISABLE_TIMBER, StateFlag.State.DENY)) {
             return;
         }
 

--- a/src/main/java/plugins/nate/smp/utils/ChatUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/ChatUtils.java
@@ -1,7 +1,10 @@
 package plugins.nate.smp.utils;
 
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 public class ChatUtils {
 
@@ -12,5 +15,9 @@ public class ChatUtils {
 
     public static void sendMessage(CommandSender sender, String message) {
         sender.sendMessage(ChatColor.translateAlternateColorCodes('&', message));
+    }
+
+    public static void createActionBar(Player player, String message) {
+        player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColor.translateAlternateColorCodes('&', message)));
     }
 }

--- a/src/main/java/plugins/nate/smp/utils/EventRegistration.java
+++ b/src/main/java/plugins/nate/smp/utils/EventRegistration.java
@@ -25,5 +25,6 @@ public class EventRegistration {
         pm.registerEvents(new AntiEntityGriefListener(), plugin);
         pm.registerEvents(new ElytraFallListener(), plugin);
         pm.registerEvents(new ExpandedRocketCraftingListener(), plugin);
+        pm.registerEvents(new TellerTradeListener(), plugin);
     }
 }

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -1,5 +1,17 @@
 package plugins.nate.smp.utils;
 
+import static plugins.nate.smp.utils.ChatUtils.PREFIX;
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
+
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
@@ -7,18 +19,13 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
-import org.bukkit.*;
-import org.bukkit.command.CommandSender;
-import org.bukkit.event.HandlerList;
-import org.bukkit.plugin.Plugin;
 import plugins.nate.smp.SMP;
-
-import static plugins.nate.smp.utils.ChatUtils.PREFIX;
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
 
 public class SMPUtils {
     public static final NamespacedKey OWNER_UUID_KEY = new NamespacedKey(SMP.getPlugin(), "ownerUUID");
     public static final NamespacedKey TRADE_LOCKED_KEY = new NamespacedKey(SMP.getPlugin(), "tradeLocked");
+    public static final NamespacedKey TELLER_TYPE_KEY = new NamespacedKey(SMP.getPlugin(), "tellerType");
+    public static final NamespacedKey PARENT_TELLER_KEY = new NamespacedKey(SMP.getPlugin(), "parentTeller");
 
     public static void reloadPlugin(CommandSender sender) {
         SMP smp = SMP.getPlugin();

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -51,6 +51,7 @@ public class SMPUtils {
     public static void log(String log) {
         SMP.getPlugin().getLogger().info(log);
     }
+    public static void severe(String log) { SMP.getPlugin().getLogger().severe(log); }
 
     public static boolean isFlagAllowedAtLocation(StateFlag flag, Location location) {
         World world = location.getWorld();

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -1,17 +1,5 @@
 package plugins.nate.smp.utils;
 
-import static plugins.nate.smp.utils.ChatUtils.PREFIX;
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
-import org.bukkit.World;
-import org.bukkit.command.CommandSender;
-import org.bukkit.event.HandlerList;
-import org.bukkit.plugin.Plugin;
-
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
@@ -19,13 +7,18 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
+import org.bukkit.*;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.Plugin;
 import plugins.nate.smp.SMP;
+
+import static plugins.nate.smp.utils.ChatUtils.PREFIX;
+import static plugins.nate.smp.utils.ChatUtils.sendMessage;
 
 public class SMPUtils {
     public static final NamespacedKey OWNER_UUID_KEY = new NamespacedKey(SMP.getPlugin(), "ownerUUID");
     public static final NamespacedKey TRADE_LOCKED_KEY = new NamespacedKey(SMP.getPlugin(), "tradeLocked");
-    public static final NamespacedKey TELLER_TYPE_KEY = new NamespacedKey(SMP.getPlugin(), "tellerType");
-    public static final NamespacedKey PARENT_TELLER_KEY = new NamespacedKey(SMP.getPlugin(), "parentTeller");
 
     public static void reloadPlugin(CommandSender sender) {
         SMP smp = SMP.getPlugin();

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -1,13 +1,10 @@
 package plugins.nate.smp.utils;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
@@ -53,16 +50,7 @@ public class SMPUtils {
     }
     public static void severe(String log) { SMP.getPlugin().getLogger().severe(log); }
 
-    public static boolean isFlagAllowedAtLocation(StateFlag flag, Location location) {
-        World world = location.getWorld();
-        if (world == null) { return false; }
 
-        RegionManager firstRegionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
-        if (firstRegionManager == null) { return false; }
-
-        ApplicableRegionSet firstSet = firstRegionManager.getApplicableRegions(BukkitAdapter.asBlockVector(location));
-        return firstSet.testState(null, flag);
-    }
 
     public static boolean isPickaxe(Material material) {
         return material == Material.WOODEN_PICKAXE ||

--- a/src/main/java/plugins/nate/smp/utils/TellerUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/TellerUtils.java
@@ -8,18 +8,19 @@ import plugins.nate.smp.SMP;
 public class TellerUtils {
     public static final NamespacedKey TELLER_TYPE_KEY = new NamespacedKey(SMP.getPlugin(), "tellerType");
     public static final NamespacedKey PARENT_TELLER_KEY = new NamespacedKey(SMP.getPlugin(), "parentTeller");
+    public static char CURRENCY_SYMBOL = '\u00D0';
 
     public static void createDepositTeller(Player player) {
         player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
             configureTeller(villager, "DEPOSIT", player);
-            createTextDisplay(player, villager, "Deposit Diamonds (" + '\u00D0' + ")");
+            createTextDisplay(player, villager, "Deposit Diamonds (" + CURRENCY_SYMBOL + ")");
         });
     }
 
     public static void createWithdrawTeller(Player player) {
         player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
             configureTeller(villager, "WITHDRAW", player);
-            createTextDisplay(player, villager, "Withdraw Diamonds (" + '\u00D0' + ")");
+            createTextDisplay(player, villager, "Withdraw Diamonds (" + CURRENCY_SYMBOL + ")");
         });
     }
 

--- a/src/main/java/plugins/nate/smp/utils/TellerUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/TellerUtils.java
@@ -1,0 +1,40 @@
+package plugins.nate.smp.utils;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.*;
+import org.bukkit.persistence.PersistentDataType;
+import plugins.nate.smp.SMP;
+
+public class TellerUtils {
+    public static final NamespacedKey TELLER_TYPE_KEY = new NamespacedKey(SMP.getPlugin(), "tellerType");
+    public static final NamespacedKey PARENT_TELLER_KEY = new NamespacedKey(SMP.getPlugin(), "parentTeller");
+
+    public static void createDepositTeller(Player player) {
+        player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
+            configureTeller(villager, "DEPOSIT", player);
+            createTextDisplay(player, villager, "Deposit Diamonds (" + '\u00D0' + ")");
+        });
+    }
+
+    public static void createWithdrawTeller(Player player) {
+        player.getWorld().spawn(player.getLocation(), Villager.class, (villager) -> {
+            configureTeller(villager, "WITHDRAW", player);
+            createTextDisplay(player, villager, "Withdraw Diamonds (" + '\u00D0' + ")");
+        });
+    }
+
+    private static void configureTeller(Villager villager, String type, Player player) {
+        villager.getPersistentDataContainer().set(TELLER_TYPE_KEY, PersistentDataType.STRING, type);
+        villager.setRotation(player.getLocation().getYaw(), player.getLocation().getPitch());
+        villager.setInvulnerable(true);
+        villager.setAI(false);
+    }
+
+    private static void createTextDisplay(Player player, Entity teller, String text) {
+        player.getWorld().spawn(player.getLocation().add(0, 2.4, 0), TextDisplay.class, (displayText) -> {
+            displayText.getPersistentDataContainer().set(PARENT_TELLER_KEY, PersistentDataType.STRING, teller.getUniqueId().toString());
+            displayText.setBillboard(Display.Billboard.CENTER);
+            displayText.setText(text);
+        });
+    }
+}

--- a/src/main/java/plugins/nate/smp/utils/TellerUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/TellerUtils.java
@@ -46,4 +46,12 @@ public class TellerUtils {
     public static boolean isWithdrawTeller(Entity entity) {
         return "WITHDRAW".equals(entity.getPersistentDataContainer().get(TELLER_TYPE_KEY, PersistentDataType.STRING));
     }
+
+    public static boolean isTeller(Entity entity) {
+        return entity.getPersistentDataContainer().has(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING);
+    }
+
+    public static String getTellerKey(Entity entity) {
+        return entity.getPersistentDataContainer().get(TellerUtils.TELLER_TYPE_KEY, PersistentDataType.STRING);
+    }
 }

--- a/src/main/java/plugins/nate/smp/utils/TellerUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/TellerUtils.java
@@ -38,4 +38,12 @@ public class TellerUtils {
             displayText.setText(text);
         });
     }
+
+    public static boolean isDepositTeller(Entity entity) {
+        return "DEPOSIT".equals(entity.getPersistentDataContainer().get(TELLER_TYPE_KEY, PersistentDataType.STRING));
+    }
+
+    public static boolean isWithdrawTeller(Entity entity) {
+        return "WITHDRAW".equals(entity.getPersistentDataContainer().get(TELLER_TYPE_KEY, PersistentDataType.STRING));
+    }
 }

--- a/src/main/java/plugins/nate/smp/utils/VaultUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/VaultUtils.java
@@ -1,0 +1,40 @@
+package plugins.nate.smp.utils;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.RegisteredServiceProvider;
+import plugins.nate.smp.SMP;
+
+public class VaultUtils {
+    public static Economy econ = null;
+
+    public static void setupEconomy(SMP plugin) {
+        if (Bukkit.getServer().getPluginManager().getPlugin("Vault") == null) {
+            plugin.getLogger().severe(String.format("[%s] - Disabled due to no Vault dependency found!", plugin.getDescription().getName()));
+            Bukkit.getServer().getPluginManager().disablePlugin(plugin);
+            return;
+        }
+
+        RegisteredServiceProvider<Economy> rsp = Bukkit.getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            plugin.getLogger().severe(String.format("[%s] - Disabled due to no Economy service found!", plugin.getDescription().getName()));
+            Bukkit.getServer().getPluginManager().disablePlugin(plugin);
+            return;
+        }
+
+        econ = rsp.getProvider();
+    }
+
+    public static boolean deposit(Player player, double amount) {
+        return econ.depositPlayer(player, amount).transactionSuccess();
+    }
+
+    public static boolean withdraw(Player player, double amount) {
+        return econ.withdrawPlayer(player, amount).transactionSuccess();
+    }
+
+    public static double getBalance(Player player) {
+        return econ.getBalance(player);
+    }
+}

--- a/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
@@ -1,14 +1,69 @@
 package plugins.nate.smp.utils;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import org.bukkit.Location;
+import org.bukkit.World;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class WorldGuardUtils {
-    public static boolean hasFlags(ProtectedRegion region, Set<StateFlag> flags) {
-        return region.getFlags().keySet().stream().anyMatch(regionFlag -> flags.stream().anyMatch(flag -> flag.equals(regionFlag)));
+    public static final FlagRegistry flagRegistry = WorldGuard.getInstance().getFlagRegistry();
+    public static StateFlag WITHER_EXPLOSIONS;
+    public static StateFlag BANK_FLAG;
+    public static StateFlag DISABLE_TIMBER;
+
+    public static final Set<StateFlag> antiBuildFlags = new HashSet<>();
+    static {
+        antiBuildFlags.add(Flags.BUILD);
+        antiBuildFlags.add(Flags.BLOCK_BREAK);
     }
 
+    public static boolean hasFlag(Location location, StateFlag flag, StateFlag.State state) {
+        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
+        BlockVector3 position = BukkitAdapter.asBlockVector(location);
 
+        if(regionManager == null) {
+            return false;
+        }
+
+        ApplicableRegionSet regionSet = regionManager.getApplicableRegions(position);
+
+        return regionSet.queryState(null, flag) == state;
+    }
+
+    public static boolean isFlagAllowedAtLocation(StateFlag flag, Location location) {
+        World world = location.getWorld();
+        if (world == null) { return false; }
+
+        RegionManager firstRegionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
+        if (firstRegionManager == null) { return false; }
+
+        ApplicableRegionSet firstSet = firstRegionManager.getApplicableRegions(BukkitAdapter.asBlockVector(location));
+        return firstSet.testState(null, flag);
+    }
+
+    public static void registerFlags() {
+        try {
+            StateFlag witherExplosionsFlag = new StateFlag("wither-explosions", true);
+            StateFlag bankFlag = new StateFlag("bank", false);
+            StateFlag disableTimberFlag = new StateFlag("disable-timber", false);
+
+            flagRegistry.register(witherExplosionsFlag);
+            flagRegistry.register(bankFlag);
+            flagRegistry.register(disableTimberFlag);
+
+            WITHER_EXPLOSIONS = witherExplosionsFlag;
+            BANK_FLAG = bankFlag;
+            DISABLE_TIMBER = disableTimberFlag;
+        } catch (FlagConflictException ignored) {}
+    }
 }

--- a/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
@@ -1,0 +1,14 @@
+package plugins.nate.smp.utils;
+
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+
+import java.util.Set;
+
+public class WorldGuardUtils {
+    public static boolean hasFlags(ProtectedRegion region, Set<StateFlag> flags) {
+        return region.getFlags().keySet().stream().anyMatch(regionFlag -> flags.stream().anyMatch(flag -> flag.equals(regionFlag)));
+    }
+
+
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,6 +7,7 @@ depend:
   - CoreProtect
   - WorldEdit
   - WorldGuard
+  - Vault
 
 commands:
   plugins:


### PR DESCRIPTION
Closes #64 

This prevents the timber enchant from being able to bypass worldguard regions with the `BUILD` or `BLOCK_BREAK` flags set to `DENY`. This adds a custom flag called `deny-timber` so when testing make sure you create a region with this flag set to `DENY`.

If this flag is anything but `DENY` timber will be allowed