### PR TITLE
Timber able to break blocks in worldguarded region

### DIFF
--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -1,9 +1,5 @@
 package plugins.nate.smp;
 
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
-import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import net.coreprotect.CoreProtectAPI;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -11,10 +7,7 @@ import plugins.nate.smp.managers.ElytraGlidingTracker;
 import plugins.nate.smp.managers.EnchantmentManager;
 import plugins.nate.smp.managers.RecipeManager;
 import plugins.nate.smp.managers.TrustManager;
-import plugins.nate.smp.utils.CommandRegistration;
-import plugins.nate.smp.utils.DependencyUtils;
-import plugins.nate.smp.utils.EventRegistration;
-import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.*;
 
 import java.io.File;
 import java.util.logging.Logger;
@@ -22,8 +15,6 @@ import java.util.logging.Logger;
 public final class SMP extends JavaPlugin {
     private static SMP plugin;
     private static CoreProtectAPI coreProtect;
-
-    public static StateFlag WITHER_EXPLOSIONS;
 
     public static final Logger logger = Logger.getLogger("Minecraft");
     public final File prefixesFile = new File(getDataFolder() + "/prefixes.yml");
@@ -50,13 +41,7 @@ public final class SMP extends JavaPlugin {
     public void onLoad() {
         super.onLoad();
 
-        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
-        try {
-            StateFlag witherExplosionsFlag = new StateFlag("wither-explosions", true);
-            registry.register(witherExplosionsFlag);
-
-            WITHER_EXPLOSIONS = witherExplosionsFlag;
-        } catch (FlagConflictException ignored) {}
+        WorldGuardUtils.registerFlags();
     }
 
     public static SMP getPlugin() {

--- a/src/main/java/plugins/nate/smp/listeners/WitherExplosionListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/WitherExplosionListener.java
@@ -5,8 +5,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
-import plugins.nate.smp.SMP;
-import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.WorldGuardUtils;
 
 import java.util.List;
 import java.util.Objects;
@@ -17,7 +16,7 @@ public class WitherExplosionListener implements Listener {
         if (event.getEntityType() == EntityType.WITHER || event.getEntityType() == EntityType.WITHER_SKULL) {
             List<Block> toRemove = event.blockList().stream()
                     .filter(Objects::nonNull)
-                    .filter(block -> !SMPUtils.isFlagAllowedAtLocation(SMP.WITHER_EXPLOSIONS, block.getLocation()))
+                    .filter(block -> !WorldGuardUtils.isFlagAllowedAtLocation(WorldGuardUtils.WITHER_EXPLOSIONS, block.getLocation()))
                     .toList();
 
             event.blockList().removeAll(toRemove);

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -1,6 +1,11 @@
 package plugins.nate.smp.listeners.enchantments;
 
-import net.coreprotect.CoreProtectAPI;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -11,18 +16,21 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import plugins.nate.smp.SMP;
 import plugins.nate.smp.managers.EnchantmentManager;
-import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
+import plugins.nate.smp.utils.WorldGuardUtils;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static plugins.nate.smp.utils.ChatUtils.PREFIX;
-import static plugins.nate.smp.utils.ChatUtils.sendMessage;
-
 
 public class TimberListener implements Listener {
+    private static final Set<StateFlag> antiBuildFlags = new HashSet<>();
+    static {
+        antiBuildFlags.add(Flags.BUILD);
+        antiBuildFlags.add(Flags.BLOCK_BREAK);
+    }
+
     private static final int MAX_BLOCKS = 192;
 
 
@@ -30,6 +38,8 @@ public class TimberListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
+
+
 
         if (!itemInHand.containsEnchantment(EnchantmentManager.ENCHANTMENTS.get("timber"))) {
             return;
@@ -68,6 +78,18 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
+        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(block.getLocation().getWorld()));
+
+        ProtectedRegion region = regionManager.getRegion("spawn");
+
+        if (region == null) {
+            return;
+        }
+
+        if (WorldGuardUtils.hasFlags(region, antiBuildFlags) && region.contains(block.getX(), block.getY(), block.getZ())) {
+            return;
+        }
+
         if (blocksDestroyed.get() >= MAX_BLOCKS || !isLog(block.getType()) || block.getType() == Material.AIR || checkedBlocks.contains(block)) {
             return;
         }

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -1,11 +1,6 @@
 package plugins.nate.smp.listeners.enchantments;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -25,11 +20,6 @@ import java.util.stream.Collectors;
 
 
 public class TimberListener implements Listener {
-    private static final Set<StateFlag> antiBuildFlags = new HashSet<>();
-    static {
-        antiBuildFlags.add(Flags.BUILD);
-        antiBuildFlags.add(Flags.BLOCK_BREAK);
-    }
 
     private static final int MAX_BLOCKS = 192;
 
@@ -38,8 +28,6 @@ public class TimberListener implements Listener {
     public void onBlockBreak(BlockBreakEvent event) {
         Player player = event.getPlayer();
         ItemStack itemInHand = player.getInventory().getItemInMainHand();
-
-
 
         if (!itemInHand.containsEnchantment(EnchantmentManager.ENCHANTMENTS.get("timber"))) {
             return;
@@ -78,15 +66,7 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
-        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(block.getLocation().getWorld()));
-
-        ProtectedRegion region = regionManager.getRegion("spawn");
-
-        if (region == null) {
-            return;
-        }
-
-        if (WorldGuardUtils.hasFlags(region, antiBuildFlags) && region.contains(block.getX(), block.getY(), block.getZ())) {
+        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.BANK_FLAG, StateFlag.State.DENY)) {
             return;
         }
 

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -66,7 +66,7 @@ public class TimberListener implements Listener {
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {
-        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.BANK_FLAG, StateFlag.State.DENY)) {
+        if (WorldGuardUtils.hasFlag(block.getLocation(), WorldGuardUtils.DISABLE_TIMBER, StateFlag.State.DENY)) {
             return;
         }
 

--- a/src/main/java/plugins/nate/smp/utils/SMPUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/SMPUtils.java
@@ -1,13 +1,10 @@
 package plugins.nate.smp.utils;
 
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.HandlerList;
 import org.bukkit.plugin.Plugin;
@@ -52,16 +49,7 @@ public class SMPUtils {
         SMP.getPlugin().getLogger().info(log);
     }
 
-    public static boolean isFlagAllowedAtLocation(StateFlag flag, Location location) {
-        World world = location.getWorld();
-        if (world == null) { return false; }
 
-        RegionManager firstRegionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
-        if (firstRegionManager == null) { return false; }
-
-        ApplicableRegionSet firstSet = firstRegionManager.getApplicableRegions(BukkitAdapter.asBlockVector(location));
-        return firstSet.testState(null, flag);
-    }
 
     public static boolean isPickaxe(Material material) {
         return material == Material.WOODEN_PICKAXE ||

--- a/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
@@ -4,7 +4,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
@@ -12,20 +11,11 @@ import com.sk89q.worldguard.protection.managers.RegionManager;
 import org.bukkit.Location;
 import org.bukkit.World;
 
-import java.util.HashSet;
-import java.util.Set;
-
 public class WorldGuardUtils {
     public static final FlagRegistry flagRegistry = WorldGuard.getInstance().getFlagRegistry();
     public static StateFlag WITHER_EXPLOSIONS;
     public static StateFlag BANK_FLAG;
     public static StateFlag DISABLE_TIMBER;
-
-    public static final Set<StateFlag> antiBuildFlags = new HashSet<>();
-    static {
-        antiBuildFlags.add(Flags.BUILD);
-        antiBuildFlags.add(Flags.BLOCK_BREAK);
-    }
 
     public static boolean hasFlag(Location location, StateFlag flag, StateFlag.State state) {
         RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));

--- a/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
@@ -1,14 +1,69 @@
 package plugins.nate.smp.utils;
 
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flags;
 import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import org.bukkit.Location;
+import org.bukkit.World;
 
+import java.util.HashSet;
 import java.util.Set;
 
 public class WorldGuardUtils {
-    public static boolean hasFlags(ProtectedRegion region, Set<StateFlag> flags) {
-        return region.getFlags().keySet().stream().anyMatch(regionFlag -> flags.stream().anyMatch(flag -> flag.equals(regionFlag)));
+    public static final FlagRegistry flagRegistry = WorldGuard.getInstance().getFlagRegistry();
+    public static StateFlag WITHER_EXPLOSIONS;
+    public static StateFlag BANK_FLAG;
+    public static StateFlag DISABLE_TIMBER;
+
+    public static final Set<StateFlag> antiBuildFlags = new HashSet<>();
+    static {
+        antiBuildFlags.add(Flags.BUILD);
+        antiBuildFlags.add(Flags.BLOCK_BREAK);
     }
 
+    public static boolean hasFlag(Location location, StateFlag flag, StateFlag.State state) {
+        RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
+        BlockVector3 position = BukkitAdapter.asBlockVector(location);
 
+        if(regionManager == null) {
+            return false;
+        }
+
+        ApplicableRegionSet regionSet = regionManager.getApplicableRegions(position);
+
+        return regionSet.queryState(null, flag) == state;
+    }
+
+    public static boolean isFlagAllowedAtLocation(StateFlag flag, Location location) {
+        World world = location.getWorld();
+        if (world == null) { return false; }
+
+        RegionManager firstRegionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(location.getWorld()));
+        if (firstRegionManager == null) { return false; }
+
+        ApplicableRegionSet firstSet = firstRegionManager.getApplicableRegions(BukkitAdapter.asBlockVector(location));
+        return firstSet.testState(null, flag);
+    }
+
+    public static void registerFlags() {
+        try {
+            StateFlag witherExplosionsFlag = new StateFlag("wither-explosions", true);
+            StateFlag bankFlag = new StateFlag("bank", false);
+            StateFlag disableTimberFlag = new StateFlag("disable-timber", false);
+
+            flagRegistry.register(witherExplosionsFlag);
+            flagRegistry.register(bankFlag);
+            flagRegistry.register(disableTimberFlag);
+
+            WITHER_EXPLOSIONS = witherExplosionsFlag;
+            BANK_FLAG = bankFlag;
+            DISABLE_TIMBER = disableTimberFlag;
+        } catch (FlagConflictException ignored) {}
+    }
 }

--- a/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
+++ b/src/main/java/plugins/nate/smp/utils/WorldGuardUtils.java
@@ -1,0 +1,14 @@
+package plugins.nate.smp.utils;
+
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+
+import java.util.Set;
+
+public class WorldGuardUtils {
+    public static boolean hasFlags(ProtectedRegion region, Set<StateFlag> flags) {
+        return region.getFlags().keySet().stream().anyMatch(regionFlag -> flags.stream().anyMatch(flag -> flag.equals(regionFlag)));
+    }
+
+
+}


### PR DESCRIPTION
Closes #64

This prevents the timber enchant from being able to bypass WorldGuard regions with the `BUILD` or `BLOCK_BREAK` flags set to `DENY`. This adds a custom flag called `deny-timber` so when testing make sure you create a region with this flag set to `DENY`.

If this flag is anything but `DENY` timber will be allowed